### PR TITLE
Gorilla Mux Support

### DIFF
--- a/handlerfunc/adapter.go
+++ b/handlerfunc/adapter.go
@@ -1,0 +1,48 @@
+package handlerfunc
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/awslabs/aws-lambda-go-api-proxy/core"
+)
+
+type HandlerFuncAdapter struct {
+	core.RequestAccessor
+	handlerFunc http.HandlerFunc
+}
+
+func New(handlerFunc http.HandlerFunc) *HandlerFuncAdapter {
+	return &HandlerFuncAdapter{
+		handlerFunc: handlerFunc,
+	}
+}
+
+func newLoggedError(format string, a ...interface{}) error {
+	err := fmt.Errorf(format, a...)
+	fmt.Println(err.Error())
+	return err
+}
+
+func (h *HandlerFuncAdapter) Proxy(event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	req, err := h.ProxyEventToHTTPRequest(event)
+	if err != nil {
+		return gatewayTimeout(), newLoggedError("Could not convert proxy event to request: %v", err)
+	}
+
+	w := core.NewProxyResponseWriter()
+	h.handlerFunc.ServeHTTP(http.ResponseWriter(w), req)
+
+	resp, err := w.GetProxyResponse()
+	if err != nil {
+		return gatewayTimeout(), newLoggedError("Error while generating proxy response: %v", err)
+	}
+
+	return resp, nil
+}
+
+// Returns a dafault Gateway Timeout (504) response
+func gatewayTimeout() events.APIGatewayProxyResponse {
+	return events.APIGatewayProxyResponse{StatusCode: http.StatusGatewayTimeout}
+}

--- a/handlerfunc/adapter_test.go
+++ b/handlerfunc/adapter_test.go
@@ -1,0 +1,38 @@
+package handlerfunc_test
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/awslabs/aws-lambda-go-api-proxy/handlerfunc"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("HandlerFuncAdapter tests", func() {
+	Context("Simple ping request", func() {
+		It("Proxies the event correctly", func() {
+			log.Println("Starting test")
+
+			handler := func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Add("unfortunately-required-header", "")
+				fmt.Fprintf(w, "Go Lambda!!")
+			}
+
+			adapter := handlerfunc.New(handler)
+
+			req := events.APIGatewayProxyRequest{
+				Path:       "/ping",
+				HTTPMethod: "GET",
+			}
+
+			resp, err := adapter.Proxy(req)
+
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+		})
+	})
+})

--- a/handlerfunc/handlerfunc_suite_test.go
+++ b/handlerfunc/handlerfunc_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestGin(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Gin Suite")
+	RunSpecs(t, "HandlerFuncAdapter Suite")
 }

--- a/handlerfunc/handlerfunc_suite_test.go
+++ b/handlerfunc/handlerfunc_suite_test.go
@@ -1,0 +1,13 @@
+package handlerfunc_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestGin(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gin Suite")
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-lambda-go-api-proxy/issues/5

*Description of changes:*
Adding support for the Gorilla Mux component of the Gorilla Web Toolkit for developers wishing to migrate their existing codebase easily into Lambda

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
