### PR TITLE
Gorillamux

### DIFF
--- a/gorillamux/adapter.go
+++ b/gorillamux/adapter.go
@@ -1,0 +1,49 @@
+package gorillamux
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/awslabs/aws-lambda-go-api-proxy/core"
+	"github.com/gorilla/mux"
+)
+
+type GorillaMuxAdapter struct {
+	core.RequestAccessor
+	router *mux.Router
+}
+
+func New(router *mux.Router) *GorillaMuxAdapter {
+	return &GorillaMuxAdapter{
+		router: router,
+	}
+}
+
+func newLoggedError(format string, a ...interface{}) error {
+	err := fmt.Errorf(format, a...)
+	fmt.Println(err.Error())
+	return err
+}
+
+func (h *GorillaMuxAdapter) Proxy(event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	req, err := h.ProxyEventToHTTPRequest(event)
+	if err != nil {
+		return gatewayTimeout(), newLoggedError("Could not convert proxy event to request: %v", err)
+	}
+
+	w := core.NewProxyResponseWriter()
+	h.router.ServeHTTP(http.ResponseWriter(w), req)
+
+	resp, err := w.GetProxyResponse()
+	if err != nil {
+		return gatewayTimeout(), newLoggedError("Error while generating proxy response: %v", err)
+	}
+
+	return resp, nil
+}
+
+// Returns a dafault Gateway Timeout (504) response
+func gatewayTimeout() events.APIGatewayProxyResponse {
+	return events.APIGatewayProxyResponse{StatusCode: http.StatusGatewayTimeout}
+}

--- a/gorillamux/adapter_test.go
+++ b/gorillamux/adapter_test.go
@@ -1,0 +1,60 @@
+package gorillamux_test
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/awslabs/aws-lambda-go-api-proxy/gorillamux"
+	"github.com/gorilla/mux"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GorillaMuxAdapter tests", func() {
+	Context("Simple ping request", func() {
+		It("Proxies the event correctly", func() {
+			log.Println("Starting test")
+
+			homeHandler := func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Add("unfortunately-required-header", "")
+				fmt.Fprintf(w, "Home Page")
+			}
+
+			productsHandler := func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Add("unfortunately-required-header", "")
+				fmt.Fprintf(w, "Products Page")
+			}
+
+			r := mux.NewRouter()
+			r.HandleFunc("/", homeHandler)
+			r.HandleFunc("/products", productsHandler)
+
+			adapter := gorillamux.New(r)
+
+			homePageReq := events.APIGatewayProxyRequest{
+				Path:       "/",
+				HTTPMethod: "GET",
+			}
+
+			homePageResp, homePageReqErr := adapter.Proxy(homePageReq)
+
+			Expect(homePageReqErr).To(BeNil())
+			Expect(homePageResp.StatusCode).To(Equal(200))
+			Expect(homePageResp.Body).To(Equal("Home Page"))
+
+			productsPageReq := events.APIGatewayProxyRequest{
+				Path:       "/products",
+				HTTPMethod: "GET",
+			}
+
+			productsPageResp, productsPageReqErr := adapter.Proxy(productsPageReq)
+
+			Expect(productsPageReqErr).To(BeNil())
+			Expect(productsPageResp.StatusCode).To(Equal(200))
+			Expect(productsPageResp.Body).To(Equal("Products Page"))
+		})
+	})
+})

--- a/gorillamux/gorilla_suite_test.go
+++ b/gorillamux/gorilla_suite_test.go
@@ -1,0 +1,13 @@
+package gorillamux_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestGin(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gorilla Mux Suite")
+}

--- a/handlerfunc/adapter.go
+++ b/handlerfunc/adapter.go
@@ -1,0 +1,48 @@
+package handlerfunc
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/awslabs/aws-lambda-go-api-proxy/core"
+)
+
+type HandlerFuncAdapter struct {
+	core.RequestAccessor
+	handlerFunc http.HandlerFunc
+}
+
+func New(handlerFunc http.HandlerFunc) *HandlerFuncAdapter {
+	return &HandlerFuncAdapter{
+		handlerFunc: handlerFunc,
+	}
+}
+
+func newLoggedError(format string, a ...interface{}) error {
+	err := fmt.Errorf(format, a...)
+	fmt.Println(err.Error())
+	return err
+}
+
+func (h *HandlerFuncAdapter) Proxy(event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	req, err := h.ProxyEventToHTTPRequest(event)
+	if err != nil {
+		return gatewayTimeout(), newLoggedError("Could not convert proxy event to request: %v", err)
+	}
+
+	w := core.NewProxyResponseWriter()
+	h.handlerFunc.ServeHTTP(http.ResponseWriter(w), req)
+
+	resp, err := w.GetProxyResponse()
+	if err != nil {
+		return gatewayTimeout(), newLoggedError("Error while generating proxy response: %v", err)
+	}
+
+	return resp, nil
+}
+
+// Returns a dafault Gateway Timeout (504) response
+func gatewayTimeout() events.APIGatewayProxyResponse {
+	return events.APIGatewayProxyResponse{StatusCode: http.StatusGatewayTimeout}
+}

--- a/handlerfunc/adapter_test.go
+++ b/handlerfunc/adapter_test.go
@@ -1,0 +1,38 @@
+package handlerfunc_test
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/awslabs/aws-lambda-go-api-proxy/handlerfunc"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("HandlerFuncAdapter tests", func() {
+	Context("Simple ping request", func() {
+		It("Proxies the event correctly", func() {
+			log.Println("Starting test")
+
+			handler := func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Add("unfortunately-required-header", "")
+				fmt.Fprintf(w, "Go Lambda!!")
+			}
+
+			adapter := handlerfunc.New(handler)
+
+			req := events.APIGatewayProxyRequest{
+				Path:       "/ping",
+				HTTPMethod: "GET",
+			}
+
+			resp, err := adapter.Proxy(req)
+
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+		})
+	})
+})

--- a/handlerfunc/handlerfunc_suite_test.go
+++ b/handlerfunc/handlerfunc_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestGin(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Gin Suite")
+	RunSpecs(t, "HandlerFuncAdapter Suite")
 }

--- a/handlerfunc/handlerfunc_suite_test.go
+++ b/handlerfunc/handlerfunc_suite_test.go
@@ -1,0 +1,13 @@
+package handlerfunc_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestGin(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gin Suite")
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -63,6 +63,18 @@
 			"revisionTime": "2018-01-25T21:43:03Z"
 		},
 		{
+			"checksumSHA1": "g/V4qrXjUGG9B+e3hB+4NAYJ5Gs=",
+			"path": "github.com/gorilla/context",
+			"revision": "08b5f424b9271eedf6f9f0ce86cb9396ed337a42",
+			"revisionTime": "2016-08-17T18:46:32Z"
+		},
+		{
+			"checksumSHA1": "gzYAE/UJ+G7yTqkdJAMActxDdxw=",
+			"path": "github.com/gorilla/mux",
+			"revision": "c0091a029979286890368b4c7b301261e448e242",
+			"revisionTime": "2018-01-20T07:58:19Z"
+		},
+		{
 			"checksumSHA1": "6L/3XPIhlmbIX4AMgW8UnguuyWo=",
 			"path": "github.com/json-iterator/go",
 			"revision": "bca911dae0735b8220ddb30236e11cff9d959f19",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-lambda-go-api-proxy/issues/5

*Description of changes:*
Added support for Gorilla Mux library for developers who wish to migrate their existing codebase easily into Lambda

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
