### PR TITLE
Custom host

### DIFF
--- a/core/types.go
+++ b/core/types.go
@@ -12,7 +12,7 @@ func GatewayTimeout() events.APIGatewayProxyResponse {
 	return events.APIGatewayProxyResponse{StatusCode: http.StatusGatewayTimeout}
 }
 
-// New Logged Error
+// NewLoggedError generates a new error and logs it to stdout
 func NewLoggedError(format string, a ...interface{}) error {
 	err := fmt.Errorf(format, a...)
 	fmt.Println(err.Error())

--- a/gorillamux/adapter_test.go
+++ b/gorillamux/adapter_test.go
@@ -2,7 +2,6 @@ package gorillamux_test
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -16,8 +15,6 @@ import (
 var _ = Describe("GorillaMuxAdapter tests", func() {
 	Context("Simple ping request", func() {
 		It("Proxies the event correctly", func() {
-			log.Println("Starting test")
-
 			homeHandler := func(w http.ResponseWriter, req *http.Request) {
 				w.Header().Add("unfortunately-required-header", "")
 				fmt.Fprintf(w, "Home Page")


### PR DESCRIPTION
Added the ability to customize the hostname for the request with the `GO_API_HOST` environment variable. The variable should contain both a protocol and host. For example `http://my-custom-host.com`

*Issue #, if available:* #13 

*Description of changes:*
* Added env variable check while creating http request
* Added tests 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
