### PR TITLE
Add support for multi value query string parameters

### DIFF
--- a/core/request.go
+++ b/core/request.go
@@ -130,6 +130,23 @@ func (r *RequestAccessor) ProxyEventToHTTPRequest(req events.APIGatewayProxyRequ
 			queryCnt++
 		}
 	}
+	if len(req.MultiValueQueryStringParameters) > 0 {
+		queryDelim := "&"
+		queryStart := false
+		if queryString == "" {
+			queryDelim = "?"
+			queryStart = true
+		}
+		for q, l := range req.MultiValueQueryStringParameters {
+			for _, v := range l {
+				queryString += queryDelim + url.QueryEscape(q) + "=" + url.QueryEscape(v)
+				if queryStart {
+					queryDelim = "&"
+					queryStart = false
+				}
+			}
+		}
+	}
 
 	path := req.Path
 	if r.stripBasePath != "" && len(r.stripBasePath) > 1 {

--- a/core/request.go
+++ b/core/request.go
@@ -118,36 +118,6 @@ func (r *RequestAccessor) ProxyEventToHTTPRequest(req events.APIGatewayProxyRequ
 		decodedBody = base64Body
 	}
 
-	queryString := ""
-	if len(req.QueryStringParameters) > 0 {
-		queryString = "?"
-		queryCnt := 0
-		for q := range req.QueryStringParameters {
-			if queryCnt > 0 {
-				queryString += "&"
-			}
-			queryString += url.QueryEscape(q) + "=" + url.QueryEscape(req.QueryStringParameters[q])
-			queryCnt++
-		}
-	}
-	if len(req.MultiValueQueryStringParameters) > 0 {
-		queryDelim := "&"
-		queryStart := false
-		if queryString == "" {
-			queryDelim = "?"
-			queryStart = true
-		}
-		for q, l := range req.MultiValueQueryStringParameters {
-			for _, v := range l {
-				queryString += queryDelim + url.QueryEscape(q) + "=" + url.QueryEscape(v)
-				if queryStart {
-					queryDelim = "&"
-					queryStart = false
-				}
-			}
-		}
-	}
-
 	path := req.Path
 	if r.stripBasePath != "" && len(r.stripBasePath) > 1 {
 		if strings.HasPrefix(path, r.stripBasePath) {
@@ -161,12 +131,24 @@ func (r *RequestAccessor) ProxyEventToHTTPRequest(req events.APIGatewayProxyRequ
 	if customAddress, ok := os.LookupEnv(CustomHostVariable); ok {
 		serverAddress = customAddress
 	}
-
 	path = serverAddress + path
+
+	if len(req.MultiValueQueryStringParameters) > 0 {
+		queryString := ""
+		for q, l := range req.MultiValueQueryStringParameters {
+			for _, v := range l {
+				if queryString != "" {
+					queryString += "&"
+				}
+				queryString += url.QueryEscape(q) + "=" + url.QueryEscape(v)
+			}
+		}
+		path += "?" + queryString
+	}
 
 	httpRequest, err := http.NewRequest(
 		strings.ToUpper(req.HTTPMethod),
-		path+queryString,
+		path,
 		bytes.NewReader(decodedBody),
 	)
 

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -58,9 +58,9 @@ var _ = Describe("RequestAccessor tests", func() {
 		})
 
 		qsRequest := getProxyRequest("/hello", "GET")
-		qsRequest.QueryStringParameters = map[string]string{
-			"hello": "1",
-			"world": "2",
+		qsRequest.MultiValueQueryStringParameters = map[string][]string{
+			"hello": {"1"},
+			"world": {"2", "3"},
 		}
 		It("Populates query string correctly", func() {
 			httpReq, err := accessor.ProxyEventToHTTPRequest(qsRequest)
@@ -73,65 +73,10 @@ var _ = Describe("RequestAccessor tests", func() {
 			Expect(query["hello"]).ToNot(BeNil())
 			Expect(query["world"]).ToNot(BeNil())
 			Expect(1).To(Equal(len(query["hello"])))
-			Expect(1).To(Equal(len(query["world"])))
-			Expect("1").To(Equal(query["hello"][0]))
-			Expect("2").To(Equal(query["world"][0]))
-		})
-
-		mvqsRequest := getProxyRequest("/hello", "GET")
-		mvqsRequest.MultiValueQueryStringParameters = map[string][]string{
-			"hello": {"1", "2"},
-			"world": {"3", "4"},
-		}
-		It("Populates multi value query string correctly", func() {
-			httpReq, err := accessor.ProxyEventToHTTPRequest(mvqsRequest)
-			Expect(err).To(BeNil())
-			Expect("/hello").To(Equal(httpReq.URL.Path))
-			Expect("GET").To(Equal(httpReq.Method))
-
-			query := httpReq.URL.Query()
-			Expect(2).To(Equal(len(query)))
-			Expect(query["hello"]).ToNot(BeNil())
-			Expect(query["world"]).ToNot(BeNil())
-			Expect(2).To(Equal(len(query["hello"])))
 			Expect(2).To(Equal(len(query["world"])))
 			Expect("1").To(Equal(query["hello"][0]))
-			Expect("2").To(Equal(query["hello"][1]))
-			Expect("3").To(Equal(query["world"][0]))
-			Expect("4").To(Equal(query["world"][1]))
-		})
-
-		qsAndMVQSRequest := getProxyRequest("/hello", "GET")
-		qsAndMVQSRequest.QueryStringParameters = map[string]string{
-			"hello1": "1",
-			"world1": "2",
-		}
-		qsAndMVQSRequest.MultiValueQueryStringParameters = map[string][]string{
-			"hello2": {"3", "4"},
-			"world2": {"5", "6"},
-		}
-		It("Populates query string and multi value query string correctly", func() {
-			httpReq, err := accessor.ProxyEventToHTTPRequest(qsAndMVQSRequest)
-			Expect(err).To(BeNil())
-			Expect("/hello").To(Equal(httpReq.URL.Path))
-			Expect("GET").To(Equal(httpReq.Method))
-
-			query := httpReq.URL.Query()
-			Expect(4).To(Equal(len(query)))
-			Expect(query["hello1"]).ToNot(BeNil())
-			Expect(query["world1"]).ToNot(BeNil())
-			Expect(query["hello2"]).ToNot(BeNil())
-			Expect(query["world2"]).ToNot(BeNil())
-			Expect(1).To(Equal(len(query["hello1"])))
-			Expect(1).To(Equal(len(query["world1"])))
-			Expect(2).To(Equal(len(query["hello2"])))
-			Expect(2).To(Equal(len(query["world2"])))
-			Expect("1").To(Equal(query["hello1"][0]))
-			Expect("2").To(Equal(query["world1"][0]))
-			Expect("3").To(Equal(query["hello2"][0]))
-			Expect("4").To(Equal(query["hello2"][1]))
-			Expect("5").To(Equal(query["world2"][0]))
-			Expect("6").To(Equal(query["world2"][1]))
+			Expect("2").To(Equal(query["world"][0]))
+			Expect("3").To(Equal(query["world"][1]))
 		})
 
 		basePathRequest := getProxyRequest("/app1/orders", "GET")

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -78,6 +78,62 @@ var _ = Describe("RequestAccessor tests", func() {
 			Expect("2").To(Equal(query["world"][0]))
 		})
 
+		mvqsRequest := getProxyRequest("/hello", "GET")
+		mvqsRequest.MultiValueQueryStringParameters = map[string][]string{
+			"hello": {"1", "2"},
+			"world": {"3", "4"},
+		}
+		It("Populates multi value query string correctly", func() {
+			httpReq, err := accessor.ProxyEventToHTTPRequest(mvqsRequest)
+			Expect(err).To(BeNil())
+			Expect("/hello").To(Equal(httpReq.URL.Path))
+			Expect("GET").To(Equal(httpReq.Method))
+
+			query := httpReq.URL.Query()
+			Expect(2).To(Equal(len(query)))
+			Expect(query["hello"]).ToNot(BeNil())
+			Expect(query["world"]).ToNot(BeNil())
+			Expect(2).To(Equal(len(query["hello"])))
+			Expect(2).To(Equal(len(query["world"])))
+			Expect("1").To(Equal(query["hello"][0]))
+			Expect("2").To(Equal(query["hello"][1]))
+			Expect("3").To(Equal(query["world"][0]))
+			Expect("4").To(Equal(query["world"][1]))
+		})
+
+		qsAndMVQSRequest := getProxyRequest("/hello", "GET")
+		qsAndMVQSRequest.QueryStringParameters = map[string]string{
+			"hello1": "1",
+			"world1": "2",
+		}
+		qsAndMVQSRequest.MultiValueQueryStringParameters = map[string][]string{
+			"hello2": {"3", "4"},
+			"world2": {"5", "6"},
+		}
+		It("Populates query string and multi value query string correctly", func() {
+			httpReq, err := accessor.ProxyEventToHTTPRequest(qsAndMVQSRequest)
+			Expect(err).To(BeNil())
+			Expect("/hello").To(Equal(httpReq.URL.Path))
+			Expect("GET").To(Equal(httpReq.Method))
+
+			query := httpReq.URL.Query()
+			Expect(4).To(Equal(len(query)))
+			Expect(query["hello1"]).ToNot(BeNil())
+			Expect(query["world1"]).ToNot(BeNil())
+			Expect(query["hello2"]).ToNot(BeNil())
+			Expect(query["world2"]).ToNot(BeNil())
+			Expect(1).To(Equal(len(query["hello1"])))
+			Expect(1).To(Equal(len(query["world1"])))
+			Expect(2).To(Equal(len(query["hello2"])))
+			Expect(2).To(Equal(len(query["world2"])))
+			Expect("1").To(Equal(query["hello1"][0]))
+			Expect("2").To(Equal(query["world1"][0]))
+			Expect("3").To(Equal(query["hello2"][0]))
+			Expect("4").To(Equal(query["hello2"][1]))
+			Expect("5").To(Equal(query["world2"][0]))
+			Expect("6").To(Equal(query["world2"][1]))
+		})
+
 		basePathRequest := getProxyRequest("/app1/orders", "GET")
 
 		It("Stips the base path correct", func() {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,28 +3,28 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "6nfly5ibFQnlDU6IpeFaZZ2q1w0=",
+			"checksumSHA1": "60T22joBzjxNa8yKzW0V4egimZI=",
 			"path": "github.com/aws/aws-lambda-go/events",
-			"revision": "5fea2b254568d4043f23d27471ae265cd33d3530",
-			"revisionTime": "2018-01-26T03:40:30Z"
+			"revision": "dcf76fe64fb68bc66dd3522c904ccf5ff1b2710a",
+			"revisionTime": "2019-01-29T19:04:57Z"
 		},
 		{
-			"checksumSHA1": "uI0hFuHj5Amsq+6TzWcczBIdWZY=",
+			"checksumSHA1": "trfV9u2UzDAypLfWLdFApLNWj0k=",
 			"path": "github.com/aws/aws-lambda-go/lambda",
-			"revision": "5fea2b254568d4043f23d27471ae265cd33d3530",
-			"revisionTime": "2018-01-26T03:40:30Z"
+			"revision": "dcf76fe64fb68bc66dd3522c904ccf5ff1b2710a",
+			"revisionTime": "2019-01-29T19:04:57Z"
 		},
 		{
 			"checksumSHA1": "d4ehJWLS4YsqFG825pgwdvKDB6A=",
 			"path": "github.com/aws/aws-lambda-go/lambda/messages",
-			"revision": "5fea2b254568d4043f23d27471ae265cd33d3530",
-			"revisionTime": "2018-01-26T03:40:30Z"
+			"revision": "dcf76fe64fb68bc66dd3522c904ccf5ff1b2710a",
+			"revisionTime": "2019-01-29T19:04:57Z"
 		},
 		{
 			"checksumSHA1": "f9MhOwQHveaPVWO6trwfqHa+W0M=",
 			"path": "github.com/aws/aws-lambda-go/lambdacontext",
-			"revision": "5fea2b254568d4043f23d27471ae265cd33d3530",
-			"revisionTime": "2018-01-26T03:40:30Z"
+			"revision": "dcf76fe64fb68bc66dd3522c904ccf5ff1b2710a",
+			"revisionTime": "2019-01-29T19:04:57Z"
 		},
 		{
 			"checksumSHA1": "QeKwBtN2df+j+4stw3bQJ6yO4EY=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,6 +15,12 @@
 			"revisionTime": "2019-01-29T19:04:57Z"
 		},
 		{
+			"checksumSHA1": "R5cnUZPkb0MPZnK822yvu4qlTXQ=",
+			"path": "github.com/aws/aws-lambda-go/lambda/handlertrace",
+			"revision": "dcf76fe64fb68bc66dd3522c904ccf5ff1b2710a",
+			"revisionTime": "2019-01-29T19:04:57Z"
+		},
+		{
 			"checksumSHA1": "d4ehJWLS4YsqFG825pgwdvKDB6A=",
 			"path": "github.com/aws/aws-lambda-go/lambda/messages",
 			"revision": "dcf76fe64fb68bc66dd3522c904ccf5ff1b2710a",


### PR DESCRIPTION
Fixes https://github.com/awslabs/aws-lambda-go-api-proxy/issues/25

* Added support for multi value query string parameters
* Added tests for only multi value query string parameters and multi value query string parameters in combination with query string parameters
* Updated aws-lambda-go dependency

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
