### PR TITLE
Use InternalServerError (500) instead of GatewayTimeoutError (504).

### DIFF
--- a/chi/adapter.go
+++ b/chi/adapter.go
@@ -34,7 +34,7 @@ func (g *ChiLambda) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayP
 	chiRequest, err := g.ProxyEventToHTTPRequest(req)
 
 	if err != nil {
-		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
+		return core.InternalServerError(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}
 
 	respWriter := core.NewProxyResponseWriter()
@@ -42,7 +42,7 @@ func (g *ChiLambda) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayP
 
 	proxyResponse, err := respWriter.GetProxyResponse()
 	if err != nil {
-		return core.GatewayTimeout(), core.NewLoggedError("Error while generating proxy response: %v", err)
+		return core.InternalServerError(), core.NewLoggedError("Error while generating proxy response: %v", err)
 	}
 
 	return proxyResponse, nil

--- a/core/types.go
+++ b/core/types.go
@@ -7,9 +7,14 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 )
 
-// GatewayTimeout returns a dafault Gateway Timeout (504) response
+// GatewayTimeout returns Gateway Timeout (504) response
 func GatewayTimeout() events.APIGatewayProxyResponse {
 	return events.APIGatewayProxyResponse{StatusCode: http.StatusGatewayTimeout}
+}
+
+// InternalServerError returns Internal Server Error (500) response
+func InternalServerError() events.APIGatewayProxyResponse {
+	return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}
 }
 
 // NewLoggedError generates a new error and logs it to stdout

--- a/gin/adapter.go
+++ b/gin/adapter.go
@@ -34,7 +34,7 @@ func (g *GinLambda) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayP
 	ginRequest, err := g.ProxyEventToHTTPRequest(req)
 
 	if err != nil {
-		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
+		return core.InternalServerError(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}
 
 	respWriter := core.NewProxyResponseWriter()
@@ -42,7 +42,7 @@ func (g *GinLambda) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayP
 
 	proxyResponse, err := respWriter.GetProxyResponse()
 	if err != nil {
-		return core.GatewayTimeout(), core.NewLoggedError("Error while generating proxy response: %v", err)
+		return core.InternalServerError(), core.NewLoggedError("Error while generating proxy response: %v", err)
 	}
 
 	return proxyResponse, nil

--- a/gorillamux/adapter.go
+++ b/gorillamux/adapter.go
@@ -22,7 +22,7 @@ func New(router *mux.Router) *GorillaMuxAdapter {
 func (h *GorillaMuxAdapter) Proxy(event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	req, err := h.ProxyEventToHTTPRequest(event)
 	if err != nil {
-		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
+		return core.InternalServerError(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}
 
 	w := core.NewProxyResponseWriter()
@@ -30,7 +30,7 @@ func (h *GorillaMuxAdapter) Proxy(event events.APIGatewayProxyRequest) (events.A
 
 	resp, err := w.GetProxyResponse()
 	if err != nil {
-		return core.GatewayTimeout(), core.NewLoggedError("Error while generating proxy response: %v", err)
+		return core.InternalServerError(), core.NewLoggedError("Error while generating proxy response: %v", err)
 	}
 
 	return resp, nil

--- a/handlerfunc/adapter.go
+++ b/handlerfunc/adapter.go
@@ -21,7 +21,7 @@ func New(handlerFunc http.HandlerFunc) *HandlerFuncAdapter {
 func (h *HandlerFuncAdapter) Proxy(event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	req, err := h.ProxyEventToHTTPRequest(event)
 	if err != nil {
-		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
+		return core.InternalServerError(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}
 
 	w := core.NewProxyResponseWriter()
@@ -29,7 +29,7 @@ func (h *HandlerFuncAdapter) Proxy(event events.APIGatewayProxyRequest) (events.
 
 	resp, err := w.GetProxyResponse()
 	if err != nil {
-		return core.GatewayTimeout(), core.NewLoggedError("Error while generating proxy response: %v", err)
+		return core.InternalServerError(), core.NewLoggedError("Error while generating proxy response: %v", err)
 	}
 
 	return resp, nil

--- a/httpadapter/adapter.go
+++ b/httpadapter/adapter.go
@@ -21,7 +21,7 @@ func New(handler http.Handler) *HandlerAdapter {
 func (h *HandlerAdapter) Proxy(event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	req, err := h.ProxyEventToHTTPRequest(event)
 	if err != nil {
-		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
+		return core.InternalServerError(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}
 
 	w := core.NewProxyResponseWriter()
@@ -29,7 +29,7 @@ func (h *HandlerAdapter) Proxy(event events.APIGatewayProxyRequest) (events.APIG
 
 	resp, err := w.GetProxyResponse()
 	if err != nil {
-		return core.GatewayTimeout(), core.NewLoggedError("Error while generating proxy response: %v", err)
+		return core.InternalServerError(), core.NewLoggedError("Error while generating proxy response: %v", err)
 	}
 
 	return resp, nil

--- a/negroni/adapter.go
+++ b/negroni/adapter.go
@@ -22,7 +22,7 @@ func New(n *negroni.Negroni) *NegroniAdapter {
 func (h *NegroniAdapter) Proxy(event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	req, err := h.ProxyEventToHTTPRequest(event)
 	if err != nil {
-		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
+		return core.InternalServerError(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}
 
 	w := core.NewProxyResponseWriter()
@@ -30,7 +30,7 @@ func (h *NegroniAdapter) Proxy(event events.APIGatewayProxyRequest) (events.APIG
 
 	resp, err := w.GetProxyResponse()
 	if err != nil {
-		return core.GatewayTimeout(), core.NewLoggedError("Error while generating proxy response: %v", err)
+		return core.InternalServerError(), core.NewLoggedError("Error while generating proxy response: %v", err)
 	}
 
 	return resp, nil


### PR DESCRIPTION
Gateway Timeout Error is not really correct error status code.
It is returned in cases when the request or response conversion fails.
Thus Internal Server Error feels more appropriate.

*Issue #, if available:* n/a

*Description of changes:* see above


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
