### PR TITLE
Added support for multi-value headers

### DIFF
--- a/core/response.go
+++ b/core/response.go
@@ -66,7 +66,7 @@ func (r *ProxyResponseWriter) WriteHeader(status int) {
 
 // GetProxyResponse converts the data passed to the response writer into
 // an events.APIGatewayProxyResponse object.
-// Returns a populated proxy response object. If the reponse is invalid, for example
+// Returns a populated proxy response object. If the response is invalid, for example
 // has no headers or an invalid status code returns an error.
 func (r *ProxyResponseWriter) GetProxyResponse() (events.APIGatewayProxyResponse, error) {
 	if r.status == defaultStatusCode {
@@ -85,16 +85,10 @@ func (r *ProxyResponseWriter) GetProxyResponse() (events.APIGatewayProxyResponse
 		isBase64 = true
 	}
 
-	proxyHeaders := make(map[string]string)
-
-	for h := range r.headers {
-		proxyHeaders[h] = r.headers.Get(h)
-	}
-
 	return events.APIGatewayProxyResponse{
-		StatusCode:      r.status,
-		Headers:         proxyHeaders,
-		Body:            output,
-		IsBase64Encoded: isBase64,
+		StatusCode:        r.status,
+		MultiValueHeaders: http.Header(r.headers),
+		Body:              output,
+		IsBase64Encoded:   isBase64,
 	}, nil
 }


### PR DESCRIPTION
**Issue #30**

**Description of changes:**
* Returns all the headers via `MultiValueHeaders` field rather than `Headers` field. This allows lambda-based service to send multiple values for the same header -- one notable use case being "Set-Cookie".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
