### PR TITLE
Add API GW Proxy context and Lambda Context to http.Request context

### DIFF
--- a/chi/adapter.go
+++ b/chi/adapter.go
@@ -37,7 +37,7 @@ func (g *ChiLambda) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayP
 
 // ProxyWithContext receives runtime context and an API Gateway proxy event,
 // transforms them into an http.Request object, and sends it to the chi.Mux for routing.
-// It returns a proxy response object gneerated from the http.ResponseWriter.
+// It returns a proxy response object generated from the http.ResponseWriter.
 func (g *ChiLambda) ProxyWithContext(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	chiRequest, err := g.ProxyEventToHTTPRequest(ctx, req)
 

--- a/chi/adapter.go
+++ b/chi/adapter.go
@@ -30,16 +30,16 @@ func New(chi *chi.Mux) *ChiLambda {
 
 // Proxy receives an API Gateway proxy event, transforms it into an http.Request
 // object, and sends it to the chi.Mux for routing.
-// It returns a proxy response object gneerated from the http.ResponseWriter.
+// It returns a proxy response object generated from the http.ResponseWriter.
 func (g *ChiLambda) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	return g.ProxyWithContext(context.Background(), req)
 }
 
-// ProxyWithContext receives runtime context and an API Gateway proxy event,
+// ProxyWithContext receives context and an API Gateway proxy event,
 // transforms them into an http.Request object, and sends it to the chi.Mux for routing.
 // It returns a proxy response object generated from the http.ResponseWriter.
 func (g *ChiLambda) ProxyWithContext(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	chiRequest, err := g.ProxyEventToHTTPRequest(ctx, req)
+	chiRequest, err := g.RequestFromEvent(ctx, req)
 
 	if err != nil {
 		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)

--- a/chi/adapter.go
+++ b/chi/adapter.go
@@ -32,14 +32,19 @@ func New(chi *chi.Mux) *ChiLambda {
 // object, and sends it to the chi.Mux for routing.
 // It returns a proxy response object generated from the http.ResponseWriter.
 func (g *ChiLambda) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	return g.ProxyWithContext(context.Background(), req)
+	chiRequest, err := g.ProxyEventToHTTPRequest(req)
+	return g.proxyInternal(chiRequest, err)
 }
 
 // ProxyWithContext receives context and an API Gateway proxy event,
 // transforms them into an http.Request object, and sends it to the chi.Mux for routing.
 // It returns a proxy response object generated from the http.ResponseWriter.
 func (g *ChiLambda) ProxyWithContext(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	chiRequest, err := g.RequestFromEvent(ctx, req)
+	chiRequest, err := g.EventToRequestWithContext(ctx, req)
+	return g.proxyInternal(chiRequest, err)
+}
+
+func (g *ChiLambda) proxyInternal(chiRequest *http.Request, err error) (events.APIGatewayProxyResponse, error) {
 
 	if err != nil {
 		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)

--- a/chi/chilambda_test.go
+++ b/chi/chilambda_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/awslabs/aws-lambda-go-api-proxy/chi"
+	chiadapter "github.com/awslabs/aws-lambda-go-api-proxy/chi"
 	"github.com/go-chi/chi"
 
 	. "github.com/onsi/ginkgo"
@@ -30,8 +30,12 @@ var _ = Describe("ChiLambda tests", func() {
 				HTTPMethod: "GET",
 			}
 
-			resp, err := adapter.Proxy(context.Background(), req)
+			resp, err := adapter.ProxyWithContext(context.Background(), req)
 
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+
+			resp, err = adapter.Proxy(req)
 			Expect(err).To(BeNil())
 			Expect(resp.StatusCode).To(Equal(200))
 		})

--- a/core/request.go
+++ b/core/request.go
@@ -4,6 +4,7 @@ package core
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -174,6 +175,20 @@ func (r *RequestAccessor) ProxyEventToHTTPRequest(req events.APIGatewayProxyRequ
 	}
 	httpRequest.Header.Add(APIGwContextHeader, string(apiGwContext))
 	httpRequest.Header.Add(APIGwStageVarsHeader, string(stageVars))
+	httpRequest = httpRequest.WithContext(toContext(httpRequest.Context(), req.RequestContext))
 
 	return httpRequest, nil
 }
+
+func toContext(parent context.Context, gwContext events.APIGatewayProxyRequestContext) context.Context {
+	parent = context.WithValue(parent, ctxKey{}, gwContext)
+	return parent
+}
+
+// GetAPIGatewayProxyRequestContext retrieve APIGatewayProxyRequestContext from context.Context
+func (r *RequestAccessor) GetAPIGatewayProxyRequestContext(req *http.Request) (events.APIGatewayProxyRequestContext, bool) {
+	v, ok := req.Context().Value(ctxKey{}).(events.APIGatewayProxyRequestContext)
+	return v, ok
+}
+
+type ctxKey struct{}

--- a/core/request.go
+++ b/core/request.go
@@ -180,7 +180,7 @@ func (r *RequestAccessor) ProxyEventToHTTPRequest(ctx context.Context, req event
 
 	lc, _ := lambdacontext.FromContext(ctx)
 	rc := requestContext{lambdaRuntime: lc, gatewayProxy: req.RequestContext}
-	ctx = context.WithValue(httpRequest.Context(), requestContextKey{},
+	ctx = context.WithValue(httpRequest.Context(), requestContextKey,
 		rc)
 	httpRequest = httpRequest.WithContext(ctx)
 	return httpRequest, nil
@@ -188,17 +188,19 @@ func (r *RequestAccessor) ProxyEventToHTTPRequest(ctx context.Context, req event
 
 // GetAPIGatewayContextFromContext retrieve APIGatewayProxyRequestContext from context.Context
 func GetAPIGatewayContextFromContext(ctx context.Context) (events.APIGatewayProxyRequestContext, bool) {
-	v, ok := ctx.Value(requestContextKey{}).(requestContext)
+	v, ok := ctx.Value(requestContextKey).(requestContext)
 	return v.gatewayProxy, ok
 }
 
 // GetRuntimeContextFromContext retrieve Lambda Runtime Context from context.Context
 func GetRuntimeContextFromContext(ctx context.Context) (*lambdacontext.LambdaContext, bool) {
-	v, ok := ctx.Value(requestContextKey{}).(requestContext)
+	v, ok := ctx.Value(requestContextKey).(requestContext)
 	return v.lambdaRuntime, ok
 }
 
-type requestContextKey struct{}
+type key struct{}
+
+var requestContextKey = &key{}
 
 type requestContext struct {
 	lambdaRuntime *lambdacontext.LambdaContext

--- a/core/request.go
+++ b/core/request.go
@@ -30,7 +30,7 @@ const DefaultServerAddress = "https://aws-serverless-go-api.com"
 // APIGwContextHeader is the custom header key used to store the
 // API Gateway context. To access the Context properties use the
 // GetAPIGatewayContext method of the RequestAccessor object.
-//const APIGwContextHeader = "X-GoLambdaProxy-ApiGw-Context"
+const APIGwContextHeader = "X-GoLambdaProxy-ApiGw-Context"
 
 // APIGwStageVarsHeader is the custom header key used to store the
 // API Gateway stage variables. To access the stage variable values
@@ -44,15 +44,21 @@ type RequestAccessor struct {
 }
 
 // GetAPIGatewayContext extracts the API Gateway context object from a
-// request's context.
+// request's custom header.
 // Returns a populated events.APIGatewayProxyRequestContext object from
-// the request context.
+// the request.
 func (r *RequestAccessor) GetAPIGatewayContext(req *http.Request) (events.APIGatewayProxyRequestContext, error) {
-	v, ok := req.Context().Value(apiGatewayProxyRequestContextKey{}).(events.APIGatewayProxyRequestContext)
-	if !ok {
-		return events.APIGatewayProxyRequestContext{}, errors.New("No APIGatewayProxyRequestContext found in request")
+	if req.Header.Get(APIGwContextHeader) == "" {
+		return events.APIGatewayProxyRequestContext{}, errors.New("No context header in request")
 	}
-	return v, nil
+	context := events.APIGatewayProxyRequestContext{}
+	err := json.Unmarshal([]byte(req.Header.Get(APIGwContextHeader)), &context)
+	if err != nil {
+		log.Println("Erorr while unmarshalling context")
+		log.Println(err)
+		return events.APIGatewayProxyRequestContext{}, err
+	}
+	return context, nil
 }
 
 // GetAPIGatewayStageVars extracts the API Gateway stage variables from a
@@ -156,11 +162,18 @@ func (r *RequestAccessor) ProxyEventToHTTPRequest(req events.APIGatewayProxyRequ
 	for h := range req.Headers {
 		httpRequest.Header.Add(h, req.Headers[h])
 	}
+
+	apiGwContext, err := json.Marshal(req.RequestContext)
+	if err != nil {
+		log.Println("Could not Marshal API GW context for custom header")
+		return nil, err
+	}
 	stageVars, err := json.Marshal(req.StageVariables)
 	if err != nil {
 		log.Println("Could not marshal stage variables for custom header")
 		return nil, err
 	}
+	httpRequest.Header.Add(APIGwContextHeader, string(apiGwContext))
 	httpRequest.Header.Add(APIGwStageVarsHeader, string(stageVars))
 	httpRequest = httpRequest.WithContext(toContext(httpRequest, req.RequestContext))
 
@@ -168,7 +181,13 @@ func (r *RequestAccessor) ProxyEventToHTTPRequest(req events.APIGatewayProxyRequ
 }
 
 func toContext(req *http.Request, gwContext events.APIGatewayProxyRequestContext) context.Context {
-	return context.WithValue(req.Context(), apiGatewayProxyRequestContextKey{}, gwContext)
+	return context.WithValue(req.Context(), ctxKey{}, gwContext)
 }
 
-type apiGatewayProxyRequestContextKey struct{}
+// GetAPIGatewayContextFromContext retrieve APIGatewayProxyRequestContext from context.Context
+func (r *RequestAccessor) GetAPIGatewayContextFromContext(req *http.Request) (events.APIGatewayProxyRequestContext, bool) {
+	v, ok := req.Context().Value(ctxKey{}).(events.APIGatewayProxyRequestContext)
+	return v, ok
+}
+
+type ctxKey struct{}

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -94,8 +94,10 @@ var _ = Describe("RequestAccessor tests", func() {
 		It("Populates context header correctly", func() {
 			httpReq, err := accessor.ProxyEventToHTTPRequest(contextRequest)
 			Expect(err).To(BeNil())
-			Expect(2).To(Equal(len(httpReq.Header)))
-			Expect(httpReq.Header.Get(core.APIGwContextHeader)).ToNot(BeNil())
+			Expect(1).To(Equal(len(httpReq.Header)))
+			context, err := accessor.GetAPIGatewayContext(httpReq)
+			Expect(err).To(BeNil())
+			Expect(context).ToNot(BeNil())
 		})
 	})
 
@@ -132,11 +134,6 @@ var _ = Describe("RequestAccessor tests", func() {
 			Expect("x").To(Equal(context.AccountID))
 			Expect("x").To(Equal(context.RequestID))
 			Expect("x").To(Equal(context.APIID))
-			proxyContext, ok := accessor.GetAPIGatewayProxyRequestContext(httpReq)
-			Expect(ok).To(BeTrue())
-			Expect("x").To(Equal(proxyContext.APIID))
-			Expect("x").To(Equal(proxyContext.RequestID))
-			Expect("x").To(Equal(proxyContext.APIID))
 			Expect("prod").To(Equal(context.Stage))
 		})
 

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -132,6 +132,11 @@ var _ = Describe("RequestAccessor tests", func() {
 			Expect("x").To(Equal(context.AccountID))
 			Expect("x").To(Equal(context.RequestID))
 			Expect("x").To(Equal(context.APIID))
+			proxyContext, ok := accessor.GetAPIGatewayProxyRequestContext(httpReq)
+			Expect(ok).To(BeTrue())
+			Expect("x").To(Equal(proxyContext.APIID))
+			Expect("x").To(Equal(proxyContext.RequestID))
+			Expect("x").To(Equal(proxyContext.APIID))
 			Expect("prod").To(Equal(context.Stage))
 		})
 

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -94,10 +94,8 @@ var _ = Describe("RequestAccessor tests", func() {
 		It("Populates context header correctly", func() {
 			httpReq, err := accessor.ProxyEventToHTTPRequest(contextRequest)
 			Expect(err).To(BeNil())
-			Expect(1).To(Equal(len(httpReq.Header)))
-			context, err := accessor.GetAPIGatewayContext(httpReq)
-			Expect(err).To(BeNil())
-			Expect(context).ToNot(BeNil())
+			Expect(2).To(Equal(len(httpReq.Header)))
+			Expect(httpReq.Header.Get(core.APIGwContextHeader)).ToNot(BeNil())
 		})
 	})
 
@@ -134,6 +132,11 @@ var _ = Describe("RequestAccessor tests", func() {
 			Expect("x").To(Equal(context.AccountID))
 			Expect("x").To(Equal(context.RequestID))
 			Expect("x").To(Equal(context.APIID))
+			proxyContext, ok := accessor.GetAPIGatewayContextFromContext(httpReq)
+			Expect(ok).To(BeTrue())
+			Expect("x").To(Equal(proxyContext.APIID))
+			Expect("x").To(Equal(proxyContext.RequestID))
+			Expect("x").To(Equal(proxyContext.APIID))
 			Expect("prod").To(Equal(context.Stage))
 		})
 

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -1,6 +1,7 @@
 package core_test
 
 import (
+	"context"
 	"encoding/base64"
 	"io/ioutil"
 	"math/rand"
@@ -18,7 +19,7 @@ var _ = Describe("RequestAccessor tests", func() {
 		accessor := core.RequestAccessor{}
 		basicRequest := getProxyRequest("/hello", "GET")
 		It("Correctly converts a basic event", func() {
-			httpReq, err := accessor.ProxyEventToHTTPRequest(basicRequest)
+			httpReq, err := accessor.ProxyEventToHTTPRequest(context.Background(), basicRequest)
 			Expect(err).To(BeNil())
 			Expect("/hello").To(Equal(httpReq.URL.Path))
 			Expect("GET").To(Equal(httpReq.Method))
@@ -26,7 +27,7 @@ var _ = Describe("RequestAccessor tests", func() {
 
 		basicRequest = getProxyRequest("/hello", "get")
 		It("Converts method to uppercase", func() {
-			httpReq, err := accessor.ProxyEventToHTTPRequest(basicRequest)
+			httpReq, err := accessor.ProxyEventToHTTPRequest(context.Background(), basicRequest)
 			Expect(err).To(BeNil())
 			Expect("/hello").To(Equal(httpReq.URL.Path))
 			Expect("GET").To(Equal(httpReq.Method))
@@ -45,7 +46,7 @@ var _ = Describe("RequestAccessor tests", func() {
 		binaryRequest.IsBase64Encoded = true
 
 		It("Decodes a base64 encoded body", func() {
-			httpReq, err := accessor.ProxyEventToHTTPRequest(binaryRequest)
+			httpReq, err := accessor.ProxyEventToHTTPRequest(context.Background(), binaryRequest)
 			Expect(err).To(BeNil())
 			Expect("/hello").To(Equal(httpReq.URL.Path))
 			Expect("POST").To(Equal(httpReq.Method))
@@ -63,7 +64,7 @@ var _ = Describe("RequestAccessor tests", func() {
 			"world": {"2", "3"},
 		}
 		It("Populates query string correctly", func() {
-			httpReq, err := accessor.ProxyEventToHTTPRequest(qsRequest)
+			httpReq, err := accessor.ProxyEventToHTTPRequest(context.Background(), qsRequest)
 			Expect(err).To(BeNil())
 			Expect("/hello").To(Equal(httpReq.URL.Path))
 			Expect("GET").To(Equal(httpReq.Method))
@@ -83,7 +84,7 @@ var _ = Describe("RequestAccessor tests", func() {
 
 		It("Stips the base path correct", func() {
 			accessor.StripBasePath("app1")
-			httpReq, err := accessor.ProxyEventToHTTPRequest(basePathRequest)
+			httpReq, err := accessor.ProxyEventToHTTPRequest(context.Background(), basePathRequest)
 			Expect(err).To(BeNil())
 			Expect("/orders").To(Equal(httpReq.URL.Path))
 		})
@@ -92,7 +93,7 @@ var _ = Describe("RequestAccessor tests", func() {
 		contextRequest.RequestContext = getRequestContext()
 
 		It("Populates context header correctly", func() {
-			httpReq, err := accessor.ProxyEventToHTTPRequest(contextRequest)
+			httpReq, err := accessor.ProxyEventToHTTPRequest(context.Background(), contextRequest)
 			Expect(err).To(BeNil())
 			Expect(2).To(Equal(len(httpReq.Header)))
 			Expect(httpReq.Header.Get(core.APIGwContextHeader)).ToNot(BeNil())
@@ -123,7 +124,7 @@ var _ = Describe("RequestAccessor tests", func() {
 			contextRequest.RequestContext = getRequestContext()
 
 			accessor := core.RequestAccessor{}
-			httpReq, err := accessor.ProxyEventToHTTPRequest(contextRequest)
+			httpReq, err := accessor.ProxyEventToHTTPRequest(context.Background(), contextRequest)
 			Expect(err).To(BeNil())
 
 			context, err := accessor.GetAPIGatewayContext(httpReq)
@@ -132,7 +133,7 @@ var _ = Describe("RequestAccessor tests", func() {
 			Expect("x").To(Equal(context.AccountID))
 			Expect("x").To(Equal(context.RequestID))
 			Expect("x").To(Equal(context.APIID))
-			proxyContext, ok := accessor.GetAPIGatewayContextFromContext(httpReq)
+			proxyContext, ok := core.GetAPIGatewayContextFromContext(httpReq.Context())
 			Expect(ok).To(BeTrue())
 			Expect("x").To(Equal(proxyContext.APIID))
 			Expect("x").To(Equal(proxyContext.RequestID))
@@ -145,7 +146,7 @@ var _ = Describe("RequestAccessor tests", func() {
 			varsRequest.StageVariables = getStageVariables()
 
 			accessor := core.RequestAccessor{}
-			httpReq, err := accessor.ProxyEventToHTTPRequest(varsRequest)
+			httpReq, err := accessor.ProxyEventToHTTPRequest(context.Background(), varsRequest)
 			Expect(err).To(BeNil())
 
 			stageVars, err := accessor.GetAPIGatewayStageVars(httpReq)
@@ -160,7 +161,7 @@ var _ = Describe("RequestAccessor tests", func() {
 		It("Populates the default hostname correctly", func() {
 			basicRequest := getProxyRequest("orders", "GET")
 			accessor := core.RequestAccessor{}
-			httpReq, err := accessor.ProxyEventToHTTPRequest(basicRequest)
+			httpReq, err := accessor.ProxyEventToHTTPRequest(context.Background(), basicRequest)
 			Expect(err).To(BeNil())
 
 			Expect(core.DefaultServerAddress).To(Equal("https://" + httpReq.Host))
@@ -172,7 +173,7 @@ var _ = Describe("RequestAccessor tests", func() {
 			os.Setenv(core.CustomHostVariable, myCustomHost)
 			basicRequest := getProxyRequest("orders", "GET")
 			accessor := core.RequestAccessor{}
-			httpReq, err := accessor.ProxyEventToHTTPRequest(basicRequest)
+			httpReq, err := accessor.ProxyEventToHTTPRequest(context.Background(), basicRequest)
 			Expect(err).To(BeNil())
 
 			Expect(myCustomHost).To(Equal("http://" + httpReq.Host))
@@ -185,7 +186,7 @@ var _ = Describe("RequestAccessor tests", func() {
 			os.Setenv(core.CustomHostVariable, myCustomHost+"/")
 			basicRequest := getProxyRequest("orders", "GET")
 			accessor := core.RequestAccessor{}
-			httpReq, err := accessor.ProxyEventToHTTPRequest(basicRequest)
+			httpReq, err := accessor.ProxyEventToHTTPRequest(context.Background(), basicRequest)
 			Expect(err).To(BeNil())
 
 			Expect(myCustomHost).To(Equal("http://" + httpReq.Host))

--- a/gin/adapter.go
+++ b/gin/adapter.go
@@ -30,16 +30,16 @@ func New(gin *gin.Engine) *GinLambda {
 
 // Proxy receives an API Gateway proxy event, transforms it into an http.Request
 // object, and sends it to the gin.Engine for routing.
-// It returns a proxy response object gneerated from the http.ResponseWriter.
+// It returns a proxy response object generated from the http.ResponseWriter.
 func (g *GinLambda) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	return g.ProxyWithContext(context.Background(), req)
 }
 
-// ProxyWithContext receives runtime context and an API Gateway proxy event,
+// ProxyWithContext receives context and an API Gateway proxy event,
 // transforms them into an http.Request object, and sends it to the gin.Engine for routing.
 // It returns a proxy response object generated from the http.ResponseWriter.
 func (g *GinLambda) ProxyWithContext(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	ginRequest, err := g.ProxyEventToHTTPRequest(ctx, req)
+	ginRequest, err := g.RequestFromEvent(ctx, req)
 
 	if err != nil {
 		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)

--- a/gin/adapter.go
+++ b/gin/adapter.go
@@ -28,13 +28,16 @@ func New(gin *gin.Engine) *GinLambda {
 	return &GinLambda{ginEngine: gin}
 }
 
+// Proxy receives an API Gateway proxy event, transforms it into an http.Request
+// object, and sends it to the gin.Engine for routing.
+// It returns a proxy response object gneerated from the http.ResponseWriter.
 func (g *GinLambda) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	return g.ProxyWithContext(context.Background(), req)
 }
 
-// Proxy receives an API Gateway proxy event, transforms it into an http.Request
-// object, and sends it to the gin.Engine for routing.
-// It returns a proxy response object gneerated from the http.ResponseWriter.
+// ProxyWithContext receives runtime context and an API Gateway proxy event,
+// transforms them into an http.Request object, and sends it to the gin.Engine for routing.
+// It returns a proxy response object generated from the http.ResponseWriter.
 func (g *GinLambda) ProxyWithContext(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	ginRequest, err := g.ProxyEventToHTTPRequest(ctx, req)
 

--- a/gin/ginlambda_test.go
+++ b/gin/ginlambda_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/awslabs/aws-lambda-go-api-proxy/gin"
+	ginadapter "github.com/awslabs/aws-lambda-go-api-proxy/gin"
 	"github.com/gin-gonic/gin"
 
 	. "github.com/onsi/ginkgo"
@@ -31,7 +31,12 @@ var _ = Describe("GinLambda tests", func() {
 				HTTPMethod: "GET",
 			}
 
-			resp, err := adapter.Proxy(context.Background(), req)
+			resp, err := adapter.ProxyWithContext(context.Background(), req)
+
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+
+			resp, err = adapter.Proxy(req)
 
 			Expect(err).To(BeNil())
 			Expect(resp.StatusCode).To(Equal(200))

--- a/gorillamux/adapter.go
+++ b/gorillamux/adapter.go
@@ -22,16 +22,16 @@ func New(router *mux.Router) *GorillaMuxAdapter {
 
 // Proxy receives an API Gateway proxy event, transforms it into an http.Request
 // object, and sends it to the mux.Router for routing.
-// It returns a proxy response object gneerated from the http.ResponseWriter.
+// It returns a proxy response object generated from the http.ResponseWriter.
 func (h *GorillaMuxAdapter) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	return h.ProxyWithContext(context.Background(), req)
 }
 
-// ProxyWithContext receives runtime context and an API Gateway proxy event,
+// ProxyWithContext receives context and an API Gateway proxy event,
 // transforms them into an http.Request object, and sends it to the mux.Router for routing.
 // It returns a proxy response object generated from the http.ResponseWriter.
 func (h *GorillaMuxAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	req, err := h.ProxyEventToHTTPRequest(ctx, event)
+	req, err := h.RequestFromEvent(ctx, event)
 	if err != nil {
 		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}

--- a/gorillamux/adapter.go
+++ b/gorillamux/adapter.go
@@ -20,14 +20,18 @@ func New(router *mux.Router) *GorillaMuxAdapter {
 	}
 }
 
-func (h *GorillaMuxAdapter) Proxy(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	req, err := h.ProxyEventToHTTPRequest(event)
+func (h *GorillaMuxAdapter) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	return h.ProxyWithContext(context.Background(), req)
+}
+
+func (h *GorillaMuxAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	req, err := h.ProxyEventToHTTPRequest(ctx, event)
 	if err != nil {
 		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}
 
 	w := core.NewProxyResponseWriter()
-	h.router.ServeHTTP(http.ResponseWriter(w), req.WithContext(ctx))
+	h.router.ServeHTTP(http.ResponseWriter(w), req)
 
 	resp, err := w.GetProxyResponse()
 	if err != nil {

--- a/gorillamux/adapter.go
+++ b/gorillamux/adapter.go
@@ -23,15 +23,20 @@ func New(router *mux.Router) *GorillaMuxAdapter {
 // Proxy receives an API Gateway proxy event, transforms it into an http.Request
 // object, and sends it to the mux.Router for routing.
 // It returns a proxy response object generated from the http.ResponseWriter.
-func (h *GorillaMuxAdapter) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	return h.ProxyWithContext(context.Background(), req)
+func (h *GorillaMuxAdapter) Proxy(event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	req, err := h.ProxyEventToHTTPRequest(event)
+	return h.proxyInternal(req, err)
 }
 
 // ProxyWithContext receives context and an API Gateway proxy event,
 // transforms them into an http.Request object, and sends it to the mux.Router for routing.
 // It returns a proxy response object generated from the http.ResponseWriter.
 func (h *GorillaMuxAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	req, err := h.RequestFromEvent(ctx, event)
+	req, err := h.EventToRequestWithContext(ctx, event)
+	return h.proxyInternal(req, err)
+}
+
+func (h *GorillaMuxAdapter) proxyInternal(req *http.Request, err error) (events.APIGatewayProxyResponse, error) {
 	if err != nil {
 		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}

--- a/gorillamux/adapter.go
+++ b/gorillamux/adapter.go
@@ -20,10 +20,16 @@ func New(router *mux.Router) *GorillaMuxAdapter {
 	}
 }
 
+// Proxy receives an API Gateway proxy event, transforms it into an http.Request
+// object, and sends it to the mux.Router for routing.
+// It returns a proxy response object gneerated from the http.ResponseWriter.
 func (h *GorillaMuxAdapter) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	return h.ProxyWithContext(context.Background(), req)
 }
 
+// ProxyWithContext receives runtime context and an API Gateway proxy event,
+// transforms them into an http.Request object, and sends it to the mux.Router for routing.
+// It returns a proxy response object generated from the http.ResponseWriter.
 func (h *GorillaMuxAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	req, err := h.ProxyEventToHTTPRequest(ctx, event)
 	if err != nil {

--- a/gorillamux/adapter_test.go
+++ b/gorillamux/adapter_test.go
@@ -37,7 +37,7 @@ var _ = Describe("GorillaMuxAdapter tests", func() {
 				HTTPMethod: "GET",
 			}
 
-			homePageResp, homePageReqErr := adapter.Proxy(context.Background(), homePageReq)
+			homePageResp, homePageReqErr := adapter.ProxyWithContext(context.Background(), homePageReq)
 
 			Expect(homePageReqErr).To(BeNil())
 			Expect(homePageResp.StatusCode).To(Equal(200))
@@ -48,7 +48,7 @@ var _ = Describe("GorillaMuxAdapter tests", func() {
 				HTTPMethod: "GET",
 			}
 
-			productsPageResp, productsPageReqErr := adapter.Proxy(context.Background(), productsPageReq)
+			productsPageResp, productsPageReqErr := adapter.Proxy(productsPageReq)
 
 			Expect(productsPageReqErr).To(BeNil())
 			Expect(productsPageResp.StatusCode).To(Equal(200))

--- a/handlerfunc/adapter.go
+++ b/handlerfunc/adapter.go
@@ -19,10 +19,16 @@ func New(handlerFunc http.HandlerFunc) *HandlerFuncAdapter {
 	}
 }
 
+// Proxy receives an API Gateway proxy event, transforms it into an http.Request
+// object, and sends it to the http.HandlerFunc for routing.
+// It returns a proxy response object gneerated from the http.ResponseWriter.
 func (h *HandlerFuncAdapter) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	return h.ProxyWithContext(context.Background(), req)
 }
 
+// ProxyWithContext receives runtime context and an API Gateway proxy event,
+// transforms them into an http.Request object, and sends it to the http.HandlerFunc for routing.
+// It returns a proxy response object generated from the http.ResponseWriter.
 func (h *HandlerFuncAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	req, err := h.ProxyEventToHTTPRequest(ctx, event)
 	if err != nil {

--- a/handlerfunc/adapter.go
+++ b/handlerfunc/adapter.go
@@ -19,14 +19,18 @@ func New(handlerFunc http.HandlerFunc) *HandlerFuncAdapter {
 	}
 }
 
-func (h *HandlerFuncAdapter) Proxy(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	req, err := h.ProxyEventToHTTPRequest(event)
+func (h *HandlerFuncAdapter) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	return h.ProxyWithContext(context.Background(), req)
+}
+
+func (h *HandlerFuncAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	req, err := h.ProxyEventToHTTPRequest(ctx, event)
 	if err != nil {
 		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}
 
 	w := core.NewProxyResponseWriter()
-	h.handlerFunc.ServeHTTP(http.ResponseWriter(w), req.WithContext(ctx))
+	h.handlerFunc.ServeHTTP(http.ResponseWriter(w), req)
 
 	resp, err := w.GetProxyResponse()
 	if err != nil {

--- a/handlerfunc/adapter.go
+++ b/handlerfunc/adapter.go
@@ -21,16 +21,16 @@ func New(handlerFunc http.HandlerFunc) *HandlerFuncAdapter {
 
 // Proxy receives an API Gateway proxy event, transforms it into an http.Request
 // object, and sends it to the http.HandlerFunc for routing.
-// It returns a proxy response object gneerated from the http.ResponseWriter.
+// It returns a proxy response object generated from the http.ResponseWriter.
 func (h *HandlerFuncAdapter) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	return h.ProxyWithContext(context.Background(), req)
 }
 
-// ProxyWithContext receives runtime context and an API Gateway proxy event,
+// ProxyWithContext receives context and an API Gateway proxy event,
 // transforms them into an http.Request object, and sends it to the http.HandlerFunc for routing.
 // It returns a proxy response object generated from the http.ResponseWriter.
 func (h *HandlerFuncAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	req, err := h.ProxyEventToHTTPRequest(ctx, event)
+	req, err := h.RequestFromEvent(ctx, event)
 	if err != nil {
 		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}

--- a/handlerfunc/adapter.go
+++ b/handlerfunc/adapter.go
@@ -22,15 +22,20 @@ func New(handlerFunc http.HandlerFunc) *HandlerFuncAdapter {
 // Proxy receives an API Gateway proxy event, transforms it into an http.Request
 // object, and sends it to the http.HandlerFunc for routing.
 // It returns a proxy response object generated from the http.ResponseWriter.
-func (h *HandlerFuncAdapter) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	return h.ProxyWithContext(context.Background(), req)
+func (h *HandlerFuncAdapter) Proxy(event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	req, err := h.ProxyEventToHTTPRequest(event)
+	return h.proxyInternal(req, err)
 }
 
 // ProxyWithContext receives context and an API Gateway proxy event,
 // transforms them into an http.Request object, and sends it to the http.HandlerFunc for routing.
 // It returns a proxy response object generated from the http.ResponseWriter.
 func (h *HandlerFuncAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	req, err := h.RequestFromEvent(ctx, event)
+	req, err := h.EventToRequestWithContext(ctx, event)
+	return h.proxyInternal(req, err)
+}
+
+func (h *HandlerFuncAdapter) proxyInternal(req *http.Request, err error) (events.APIGatewayProxyResponse, error) {
 	if err != nil {
 		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}

--- a/handlerfunc/adapter_test.go
+++ b/handlerfunc/adapter_test.go
@@ -30,7 +30,12 @@ var _ = Describe("HandlerFuncAdapter tests", func() {
 				HTTPMethod: "GET",
 			}
 
-			resp, err := adapter.Proxy(context.Background(), req)
+			resp, err := adapter.ProxyWithContext(context.Background(), req)
+
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+
+			resp, err = adapter.Proxy(req)
 
 			Expect(err).To(BeNil())
 			Expect(resp.StatusCode).To(Equal(200))

--- a/httpadapter/adapter.go
+++ b/httpadapter/adapter.go
@@ -21,16 +21,16 @@ func New(handler http.Handler) *HandlerAdapter {
 
 // Proxy receives an API Gateway proxy event, transforms it into an http.Request
 // object, and sends it to the http.HandlerFunc for routing.
-// It returns a proxy response object gneerated from the http.Handler.
+// It returns a proxy response object generated from the http.Handler.
 func (h *HandlerAdapter) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	return h.ProxyWithContext(context.Background(), req)
 }
 
-// ProxyWithContext receives runtime context and an API Gateway proxy event,
+// ProxyWithContext receives context and an API Gateway proxy event,
 // transforms them into an http.Request object, and sends it to the http.Handler for routing.
 // It returns a proxy response object generated from the http.ResponseWriter.
 func (h *HandlerAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	req, err := h.ProxyEventToHTTPRequest(ctx, event)
+	req, err := h.RequestFromEvent(ctx, event)
 	if err != nil {
 		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}

--- a/httpadapter/adapter.go
+++ b/httpadapter/adapter.go
@@ -19,10 +19,16 @@ func New(handler http.Handler) *HandlerAdapter {
 	}
 }
 
+// Proxy receives an API Gateway proxy event, transforms it into an http.Request
+// object, and sends it to the http.HandlerFunc for routing.
+// It returns a proxy response object gneerated from the http.Handler.
 func (h *HandlerAdapter) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	return h.ProxyWithContext(context.Background(), req)
 }
 
+// ProxyWithContext receives runtime context and an API Gateway proxy event,
+// transforms them into an http.Request object, and sends it to the http.Handler for routing.
+// It returns a proxy response object generated from the http.ResponseWriter.
 func (h *HandlerAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	req, err := h.ProxyEventToHTTPRequest(ctx, event)
 	if err != nil {

--- a/httpadapter/adapter.go
+++ b/httpadapter/adapter.go
@@ -22,15 +22,20 @@ func New(handler http.Handler) *HandlerAdapter {
 // Proxy receives an API Gateway proxy event, transforms it into an http.Request
 // object, and sends it to the http.HandlerFunc for routing.
 // It returns a proxy response object generated from the http.Handler.
-func (h *HandlerAdapter) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	return h.ProxyWithContext(context.Background(), req)
+func (h *HandlerAdapter) Proxy(event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	req, err := h.ProxyEventToHTTPRequest(event)
+	return h.proxyInternal(req, err)
 }
 
 // ProxyWithContext receives context and an API Gateway proxy event,
 // transforms them into an http.Request object, and sends it to the http.Handler for routing.
 // It returns a proxy response object generated from the http.ResponseWriter.
 func (h *HandlerAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	req, err := h.RequestFromEvent(ctx, event)
+	req, err := h.EventToRequestWithContext(ctx, event)
+	return h.proxyInternal(req, err)
+}
+
+func (h *HandlerAdapter) proxyInternal(req *http.Request, err error) (events.APIGatewayProxyResponse, error) {
 	if err != nil {
 		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}

--- a/httpadapter/adapter.go
+++ b/httpadapter/adapter.go
@@ -19,14 +19,18 @@ func New(handler http.Handler) *HandlerAdapter {
 	}
 }
 
-func (h *HandlerAdapter) Proxy(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	req, err := h.ProxyEventToHTTPRequest(event)
+func (h *HandlerAdapter) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	return h.ProxyWithContext(context.Background(), req)
+}
+
+func (h *HandlerAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	req, err := h.ProxyEventToHTTPRequest(ctx, event)
 	if err != nil {
 		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}
 
 	w := core.NewProxyResponseWriter()
-	h.handler.ServeHTTP(http.ResponseWriter(w), req.WithContext(ctx))
+	h.handler.ServeHTTP(http.ResponseWriter(w), req)
 
 	resp, err := w.GetProxyResponse()
 	if err != nil {

--- a/httpadapter/adapter_test.go
+++ b/httpadapter/adapter_test.go
@@ -37,7 +37,12 @@ var _ = Describe("HTTPAdapter tests", func() {
 				HTTPMethod: "GET",
 			}
 
-			resp, err := adapter.Proxy(context.Background(), req)
+			resp, err := adapter.ProxyWithContext(context.Background(), req)
+
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+
+			resp, err = adapter.Proxy(req)
 
 			Expect(err).To(BeNil())
 			Expect(resp.StatusCode).To(Equal(200))

--- a/negroni/adapter.go
+++ b/negroni/adapter.go
@@ -20,14 +20,18 @@ func New(n *negroni.Negroni) *NegroniAdapter {
 	}
 }
 
-func (h *NegroniAdapter) Proxy(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	req, err := h.ProxyEventToHTTPRequest(event)
+func (h *NegroniAdapter) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	return h.ProxyWithContext(context.Background(), req)
+}
+
+func (h *NegroniAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	req, err := h.ProxyEventToHTTPRequest(ctx, event)
 	if err != nil {
 		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}
 
 	w := core.NewProxyResponseWriter()
-	h.n.ServeHTTP(http.ResponseWriter(w), req.WithContext(ctx))
+	h.n.ServeHTTP(http.ResponseWriter(w), req)
 
 	resp, err := w.GetProxyResponse()
 	if err != nil {

--- a/negroni/adapter.go
+++ b/negroni/adapter.go
@@ -20,10 +20,16 @@ func New(n *negroni.Negroni) *NegroniAdapter {
 	}
 }
 
+// Proxy receives an API Gateway proxy event, transforms it into an http.Request
+// object, and sends it to the negroni.Negroni for routing.
+// It returns a proxy response object gneerated from the http.Handler.
 func (h *NegroniAdapter) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	return h.ProxyWithContext(context.Background(), req)
 }
 
+// ProxyWithContext receives runtime context and an API Gateway proxy event,
+// transforms them into an http.Request object, and sends it to the negroni.Negroni for routing.
+// It returns a proxy response object generated from the http.ResponseWriter.
 func (h *NegroniAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	req, err := h.ProxyEventToHTTPRequest(ctx, event)
 	if err != nil {

--- a/negroni/adapter.go
+++ b/negroni/adapter.go
@@ -22,16 +22,16 @@ func New(n *negroni.Negroni) *NegroniAdapter {
 
 // Proxy receives an API Gateway proxy event, transforms it into an http.Request
 // object, and sends it to the negroni.Negroni for routing.
-// It returns a proxy response object gneerated from the http.Handler.
+// It returns a proxy response object generated from the http.Handler.
 func (h *NegroniAdapter) Proxy(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	return h.ProxyWithContext(context.Background(), req)
 }
 
-// ProxyWithContext receives runtime context and an API Gateway proxy event,
+// ProxyWithContext receives context and an API Gateway proxy event,
 // transforms them into an http.Request object, and sends it to the negroni.Negroni for routing.
 // It returns a proxy response object generated from the http.ResponseWriter.
 func (h *NegroniAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	req, err := h.ProxyEventToHTTPRequest(ctx, event)
+	req, err := h.RequestFromEvent(ctx, event)
 	if err != nil {
 		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}

--- a/negroni/adapter_test.go
+++ b/negroni/adapter_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/awslabs/aws-lambda-go-api-proxy/negroni"
+	negroniadapter "github.com/awslabs/aws-lambda-go-api-proxy/negroni"
 	"github.com/urfave/negroni"
 
 	. "github.com/onsi/ginkgo"
@@ -43,7 +43,7 @@ var _ = Describe("NegroniAdapter tests", func() {
 				HTTPMethod: "GET",
 			}
 
-			homePageResp, homePageReqErr := adapter.Proxy(context.Background(), homePageReq)
+			homePageResp, homePageReqErr := adapter.ProxyWithContext(context.Background(), homePageReq)
 
 			Expect(homePageReqErr).To(BeNil())
 			Expect(homePageResp.StatusCode).To(Equal(200))
@@ -54,7 +54,7 @@ var _ = Describe("NegroniAdapter tests", func() {
 				HTTPMethod: "GET",
 			}
 
-			productsPageResp, productsPageReqErr := adapter.Proxy(context.Background(), productsPageReq)
+			productsPageResp, productsPageReqErr := adapter.Proxy(productsPageReq)
 
 			Expect(productsPageReqErr).To(BeNil())
 			Expect(productsPageResp.StatusCode).To(Equal(200))

--- a/sample/main.go
+++ b/sample/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/awslabs/aws-lambda-go-api-proxy/gin"
+	ginadapter "github.com/awslabs/aws-lambda-go-api-proxy/gin"
 	"github.com/gin-gonic/gin"
 )
 
@@ -28,7 +28,7 @@ func Handler(ctx context.Context, req events.APIGatewayProxyRequest) (events.API
 		ginLambda = ginadapter.New(r)
 	}
 
-	return ginLambda.Proxy(ctx, req)
+	return ginLambda.ProxyWithContext(ctx, req)
 }
 
 func main() {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-lambda-go-api-proxy/issues/27
*Description of changes:*
* Add ProxyWithContext method for all adapters
* Provide reverse compatibility
* Pass Gateway Proxy Context and Lambda context in http.Request context for better security, still keep it in header also for reverse compatibility

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
