### PR TITLE
Add support for query string parameters again

### DIFF
--- a/core/request.go
+++ b/core/request.go
@@ -166,6 +166,17 @@ func (r *RequestAccessor) EventToRequest(req events.APIGatewayProxyRequest) (*ht
 			}
 		}
 		path += "?" + queryString
+	} else if len(req.QueryStringParameters) > 0 {
+		// Support `QueryStringParameters` for backward compatibility.
+		// https://github.com/awslabs/aws-lambda-go-api-proxy/issues/37
+		queryString := ""
+		for q := range req.QueryStringParameters {
+			if queryString != "" {
+				queryString += "&"
+			}
+			queryString += url.QueryEscape(q) + "=" + url.QueryEscape(req.QueryStringParameters[q])
+		}
+		path += "?" + queryString
 	}
 
 	httpRequest, err := http.NewRequest(


### PR DESCRIPTION
*Issue https://github.com/awslabs/aws-lambda-go-api-proxy/issues/37:*

This PR support `QueryStringParameters` again while avoiding adding the same parameter twice for tools that have not yet supported `MultiValueQueryStringParameters` yet (like [aws-sam-cli](https://github.com/awslabs/aws-sam-cli/pull/741))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
