### PR TITLE
Fix ProxyWithContext to use original context

### DIFF
--- a/core/request.go
+++ b/core/request.go
@@ -215,7 +215,7 @@ func addToHeader(req *http.Request, apiGwRequest events.APIGatewayProxyRequest) 
 func addToContext(ctx context.Context, req *http.Request, apiGwRequest events.APIGatewayProxyRequest) *http.Request {
 	lc, _ := lambdacontext.FromContext(ctx)
 	rc := requestContext{lambdaContext: lc, gatewayProxyContext: apiGwRequest.RequestContext, stageVars: apiGwRequest.StageVariables}
-	ctx = context.WithValue(req.Context(), ctxKey{}, rc)
+	ctx = context.WithValue(ctx, ctxKey{}, rc)
 	return req.WithContext(ctx)
 }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-lambda-go-api-proxy/issues/27

*Description of changes:*
Context got from request in `http.HandlerFunc` is not the one passed as the parameter of ProxyWithContext. It is replaced a new one.
I fixed it to use the context passed as the parameter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
