### PR TITLE
Implement http close notifier

### DIFF
--- a/core/response.go
+++ b/core/response.go
@@ -85,7 +85,7 @@ func (r *ProxyResponseWriter) WriteHeader(status int) {
 // Returns a populated proxy response object. If the response is invalid, for example
 // has no headers or an invalid status code returns an error.
 func (r *ProxyResponseWriter) GetProxyResponse() (events.APIGatewayProxyResponse, error) {
-	defer r.notifyClosed()
+	r.notifyClosed()
 
 	if r.status == defaultStatusCode {
 		return events.APIGatewayProxyResponse{}, errors.New("Status code not set on response")


### PR DESCRIPTION
Scenario: Reverse Proxying. 

When this patch is applied, http.CloseNotifier gets implemented, thus not generating errors such as this:

```

2019/09/13 00:34:25 [Recovery] 2019/09/13 - 00:34:25 panic recovered:
2019-09-13T00:34:25.807Z interface conversion: *core.ProxyResponseWriter is not http.CloseNotifier: missing method CloseNotify
2019-09-13T00:34:25.807Z /home/aldrin/.go/src/runtime/iface.go:85 (0x40a906)
2019-09-13T00:34:25.807Z /home/aldrin/.go/src/runtime/iface.go:449 (0x40b8e4)
2019-09-13T00:34:25.807Z /home/aldrin/go/pkg/mod/github.com/gin-gonic/gin@v1.4.0/response_writer.go:112 (0x8fcf02)
2019-09-13T00:34:25.807Z /home/aldrin/.go/src/net/http/httputil/reverseproxy.go:188 (0x8ee67f)
2019-09-13T00:34:25.807Z /home/aldrin/projetos/sources/xtrigger/routes/proxy.go:31 (0x9da7d7)
2019-09-13T00:34:25.807Z /home/aldrin/go/pkg/mod/github.com/gin-gonic/gin@v1.4.0/context.go:124 (0x8f100a)
2019-09-13T00:34:25.807Z /home/aldrin/go/pkg/mod/github.com/gin-gonic/gin@v1.4.0/recovery.go:83 (0x904243)
2019-09-13T00:34:25.807Z /home/aldrin/go/pkg/mod/github.com/gin-gonic/gin@v1.4.0/context.go:124 (0x8f100a)
2019-09-13T00:34:25.807Z /home/aldrin/go/pkg/mod/github.com/gin-gonic/gin@v1.4.0/logger.go:240 (0x9032f0)
2019-09-13T00:34:25.807Z /home/aldrin/go/pkg/mod/github.com/gin-gonic/gin@v1.4.0/context.go:124 (0x8f100a)
2019-09-13T00:34:25.807Z /home/aldrin/go/pkg/mod/github.com/gin-gonic/gin@v1.4.0/gin.go:389 (0x8fa8c1)
2019-09-13T00:34:25.807Z /home/aldrin/go/pkg/mod/github.com/gin-gonic/gin@v1.4.0/gin.go:351 (0x8fa0f3)
2019-09-13T00:34:25.807Z /home/aldrin/go/pkg/mod/github.com/aldrinleal/aws-lambda-go-api-proxy@v0.4.2-0.20190730202202-19825165bd2f/gin/adapter.go:54 (0x906252)
2019-09-13T00:34:25.807Z /home/aldrin/go/pkg/mod/github.com/aldrinleal/aws-lambda-go-api-proxy@v0.4.2-0.20190730202202-19825165bd2f/gin/adapter.go:44 (0x906011)
2019-09-13T00:34:25.807Z /home/aldrin/projetos/sources/xtrigger/cmd/xtrigger/main.go:39 (0x9db217)
2019-09-13T00:34:25.807Z /home/aldrin/.go/src/reflect/value.go:460 (0x48f4a5)
2019-09-13T00:34:25.807Z /home/aldrin/.go/src/reflect/value.go:321 (0x48ec63)
2019-09-13T00:34:25.807Z /home/aldrin/go/pkg/mod/github.com/aws/aws-lambda-go@v1.12.0/lambda/handler.go:124 (0x780f20)
2019-09-13T00:34:25.807Z /home/aldrin/go/pkg/mod/github.com/aws/aws-lambda-go@v1.12.0/lambda/handler.go:24 (0x77f84e)
2019-09-13T00:34:25.807Z /home/aldrin/go/pkg/mod/github.com/aws/aws-lambda-go@v1.12.0/lambda/function.go:63 (0x77f318)
2019-09-13T00:34:25.807Z /home/aldrin/.go/src/reflect/value.go:460 (0x48f4a5)
2019-09-13T00:34:25.807Z /home/aldrin/.go/src/reflect/value.go:321 (0x48ec63)
2019-09-13T00:34:25.807Z /home/aldrin/.go/src/net/rpc/server.go:377 (0x77a92e)
2019-09-13T00:34:25.807Z /home/aldrin/.go/src/runtime/asm_amd64.s:1357 (0x45bec0)
2019-09-13T00:34:25.807Z 
```