### PR TITLE
Replacing -1 with defaultStatusCode

### DIFF
--- a/core/response.go
+++ b/core/response.go
@@ -59,7 +59,7 @@ func (r *ProxyResponseWriter) Header() http.Header {
 // was set before with the WriteHeader method it sets the status
 // for the response to 200 OK.
 func (r *ProxyResponseWriter) Write(body []byte) (int, error) {
-	if r.status == -1 {
+	if r.status == defaultStatusCode {
 		r.status = http.StatusOK
 	}
 


### PR DESCRIPTION
`defaultStatusCode` is used elsewhere in place of `-1`.  Looks like one value in the `Write` method was missed.  This cleans that up.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
