### PR TITLE
Handling multi-value request headers

### DIFF
--- a/core/request.go
+++ b/core/request.go
@@ -190,9 +190,19 @@ func (r *RequestAccessor) EventToRequest(req events.APIGatewayProxyRequest) (*ht
 		log.Println(err)
 		return nil, err
 	}
-	for h := range req.Headers {
-		httpRequest.Header.Add(h, req.Headers[h])
+
+	if req.MultiValueHeaders != nil {
+		for k, values := range req.MultiValueHeaders {
+			for _, value := range values {
+				httpRequest.Header.Add(k, value)
+			}
+		}
+	} else {
+		for h := range req.Headers {
+			httpRequest.Header.Add(h, req.Headers[h])
+		}
 	}
+
 	return httpRequest, nil
 }
 

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambdacontext"
@@ -107,6 +108,44 @@ var _ = Describe("RequestAccessor tests", func() {
 			Expect(1).To(Equal(len(query["world"])))
 			Expect("1").To(Equal(query["hello"][0]))
 			Expect("2").To(Equal(query["world"][0]))
+		})
+
+		mvhRequest := getProxyRequest("/hello", "GET")
+		mvhRequest.MultiValueHeaders = map[string][]string{
+			"hello": {"1"},
+			"world": {"2", "3"},
+		}
+		It("Populates multiple value headers correctly", func() {
+			httpReq, err := accessor.EventToRequestWithContext(context.Background(), mvhRequest)
+			Expect(err).To(BeNil())
+			Expect("/hello").To(Equal(httpReq.URL.Path))
+			Expect("GET").To(Equal(httpReq.Method))
+
+			headers := httpReq.Header
+			Expect(2).To(Equal(len(headers)))
+
+			for k, value := range headers {
+				Expect(value).To(Equal(mvhRequest.MultiValueHeaders[strings.ToLower(k)]))
+			}
+		})
+
+		svhRequest := getProxyRequest("/hello", "GET")
+		svhRequest.Headers = map[string]string{
+			"hello": "1",
+			"world": "2",
+		}
+		It("Populates single value headers correctly", func() {
+			httpReq, err := accessor.EventToRequestWithContext(context.Background(), svhRequest)
+			Expect(err).To(BeNil())
+			Expect("/hello").To(Equal(httpReq.URL.Path))
+			Expect("GET").To(Equal(httpReq.Method))
+
+			headers := httpReq.Header
+			Expect(2).To(Equal(len(headers)))
+
+			for k, value := range headers {
+				Expect(value[0]).To(Equal(svhRequest.Headers[strings.ToLower(k)]))
+			}
 		})
 
 		basePathRequest := getProxyRequest("/app1/orders", "GET")


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-lambda-go-api-proxy/issues/63

*Description of changes:* There is currently an issue where multi-value request headers are not properly being handled and set. This causes 406 errors in requests with multi-value headers enabled.

MultiValueHeaders is a `map[string][]string` whereas Headers is a `map[string]string`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
