### PR TITLE
To avoid duplicate response headers, only populate MultiValueHeaders

### DIFF
--- a/core/response.go
+++ b/core/response.go
@@ -103,15 +103,8 @@ func (r *ProxyResponseWriter) GetProxyResponse() (events.APIGatewayProxyResponse
 		isBase64 = true
 	}
 
-	proxyHeaders := make(map[string]string)
-
-	for h := range r.headers {
-		proxyHeaders[h] = r.headers.Get(h)
-	}
-
 	return events.APIGatewayProxyResponse{
 		StatusCode:        r.status,
-		Headers:           proxyHeaders,
 		MultiValueHeaders: http.Header(r.headers),
 		Body:              output,
 		IsBase64Encoded:   isBase64,

--- a/core/response_test.go
+++ b/core/response_test.go
@@ -153,8 +153,8 @@ var _ = Describe("ResponseWriter tests", func() {
 			proxyResponse, err := response.GetProxyResponse()
 			Expect(err).To(BeNil())
 
-			// Headers are also written to `Headers` field
-			Expect(1).To(Equal(len(proxyResponse.Headers)))
+			// Headers are not also written to `Headers` field
+			Expect(0).To(Equal(len(proxyResponse.Headers)))
 			Expect(1).To(Equal(len(proxyResponse.MultiValueHeaders["Content-Type"])))
 			Expect("application/json").To(Equal(proxyResponse.MultiValueHeaders["Content-Type"][0]))
 		})
@@ -167,8 +167,8 @@ var _ = Describe("ResponseWriter tests", func() {
 			proxyResponse, err := response.GetProxyResponse()
 			Expect(err).To(BeNil())
 
-			// Headers are also written to `Headers` field
-			Expect(2).To(Equal(len(proxyResponse.Headers)))
+			// Headers are not also written to `Headers` field
+			Expect(0).To(Equal(len(proxyResponse.Headers)))
 
 			// There are two headers here because Content-Type is always written implicitly
 			Expect(2).To(Equal(len(proxyResponse.MultiValueHeaders["Set-Cookie"])))


### PR DESCRIPTION
*Issue #, if available:*
None, but I can create one if necessary.

*Description of changes:* 
We were seeing duplicated CORS headers in our app, which caused the browser to not allow the connection. The problem appears to be caused by code which puts the response headers in both `Headers` and `MultiValueHeaders`. According to [the docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#apigateway-multivalue-headers-and-parameters):

> If you specify values for both headers and multiValueHeaders, API Gateway merges them into a single list. If the same key-value pair is specified in both, only the values from multiValueHeaders will appear in the merged list.

So this may be a Lambda bug. But I can't see any reason to populate both maps and this patch appears to fix the duplicate headers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
