### PR TITLE
Use buffered channels for close notify signaling

### DIFF
--- a/core/response.go
+++ b/core/response.go
@@ -37,7 +37,7 @@ func NewProxyResponseWriter() *ProxyResponseWriter {
 }
 
 func (r *ProxyResponseWriter) CloseNotify() <-chan bool {
-	ch := make(chan bool)
+	ch := make(chan bool, 1)
 
 	r.observers = append(r.observers, ch)
 


### PR DESCRIPTION
Using unbuffered channels results in potential blocks during `notifyClosed` if calling code fails or is otherwise unable to receive on the returned channel. In particular this fixes an issue where calling code was awaiting either notify close or context done. When context done happened first this caused the notifyClose call to hang, causing an api gateway timeout.
