### PR TITLE
Fix spelling and group constants

### DIFF
--- a/core/request.go
+++ b/core/request.go
@@ -19,21 +19,23 @@ import (
 	"github.com/aws/aws-lambda-go/lambdacontext"
 )
 
-// CustomHostVariable is the name of the environment variable that contains
-// the custom hostname for the request. If this variable is not set the framework
-// reverts to `RequestContext.DomainName`. The value for a custom host should
-// include a protocol: http://my-custom.host.com
-const CustomHostVariable = "GO_API_HOST"
+const (
+	// CustomHostVariable is the name of the environment variable that contains
+	// the custom hostname for the request. If this variable is not set the framework
+	// reverts to `RequestContext.DomainName`. The value for a custom host should
+	// include a protocol: http://my-custom.host.com
+	CustomHostVariable = "GO_API_HOST"
 
-// APIGwContextHeader is the custom header key used to store the
-// API Gateway context. To access the Context properties use the
-// GetAPIGatewayContext method of the RequestAccessor object.
-const APIGwContextHeader = "X-GoLambdaProxy-ApiGw-Context"
+	// APIGwContextHeader is the custom header key used to store the
+	// API Gateway context. To access the Context properties use the
+	// GetAPIGatewayContext method of the RequestAccessor object.
+	APIGwContextHeader = "X-GoLambdaProxy-ApiGw-Context"
 
-// APIGwStageVarsHeader is the custom header key used to store the
-// API Gateway stage variables. To access the stage variable values
-// use the GetAPIGatewayStageVars method of the RequestAccessor object.
-const APIGwStageVarsHeader = "X-GoLambdaProxy-ApiGw-StageVars"
+	// APIGwStageVarsHeader is the custom header key used to store the
+	// API Gateway stage variables. To access the stage variable values
+	// use the GetAPIGatewayStageVars method of the RequestAccessor object.
+	APIGwStageVarsHeader = "X-GoLambdaProxy-ApiGw-StageVars"
+)
 
 // RequestAccessor objects give access to custom API Gateway properties
 // in the request.

--- a/core/request.go
+++ b/core/request.go
@@ -52,7 +52,7 @@ func (r *RequestAccessor) GetAPIGatewayContext(req *http.Request) (events.APIGat
 	context := events.APIGatewayProxyRequestContext{}
 	err := json.Unmarshal([]byte(req.Header.Get(APIGwContextHeader)), &context)
 	if err != nil {
-		log.Println("Erorr while unmarshalling context")
+		log.Println("Error while unmarshalling context")
 		log.Println(err)
 		return events.APIGatewayProxyRequestContext{}, err
 	}
@@ -70,7 +70,7 @@ func (r *RequestAccessor) GetAPIGatewayStageVars(req *http.Request) (map[string]
 	}
 	err := json.Unmarshal([]byte(req.Header.Get(APIGwStageVarsHeader)), &stageVars)
 	if err != nil {
-		log.Println("Erorr while unmarshalling stage variables")
+		log.Println("Error while unmarshalling stage variables")
 		log.Println(err)
 		return stageVars, err
 	}

--- a/core/response.go
+++ b/core/response.go
@@ -12,8 +12,10 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 )
 
-const defaultStatusCode = -1
-const contentTypeHeaderKey = "Content-Type"
+const (
+	defaultStatusCode    = -1
+	contentTypeHeaderKey = "Content-Type"
+)
 
 // ProxyResponseWriter implements http.ResponseWriter and adds the method
 // necessary to return an events.APIGatewayProxyResponse object


### PR DESCRIPTION
👋 

Two small things:

- Noted a small spelling mistake in error messages (`Erorr`, not `Error`).
- Grouped `const` blocks (maybe we don't like this coding style?).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
