### PR TITLE
Remove dead code (struct{}) from HTTP adapter test

### DIFF
--- a/httpadapter/adapter_test.go
+++ b/httpadapter/adapter_test.go
@@ -13,13 +13,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-type handler struct{}
-
-func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	w.Header().Add("unfortunately-required-header", "")
-	fmt.Fprintf(w, "Go Lambda!!")
-}
-
 var _ = Describe("HTTPAdapter tests", func() {
 	Context("Simple ping request", func() {
 		It("Proxies the event correctly", func() {


### PR DESCRIPTION
Little housekeeping - found this one via a quick `golangci-lint` run - a struct that isn't used in a test case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
