### PR TITLE
[fiber] Ensure content-type is set

### DIFF
--- a/fiber/adapter.go
+++ b/fiber/adapter.go
@@ -77,6 +77,7 @@ func (f *FiberLambda) adaptor(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, utils.StatusMessage(fiber.StatusInternalServerError), fiber.StatusInternalServerError)
 		return
 	}
+	req.Header.SetContentType(r.Header.Get("Content-Type"))
 	req.Header.SetContentLength(len(body))
 	_, _ = req.BodyWriter().Write(body)
 


### PR DESCRIPTION
## Issue

https://github.com/gofiber/fiber/issues/1223

## Description of changes

This PR fixes an issue where POST requests made to a lambda which uses the Fiber adapter were not interpreted correctly. 

Indeed, the `content-type` header from the source `events.APIGatewayProxyRequest` object was not mapped to the `fasthttp.Request` object, making Fiber context method `c.FormFile()` fail, as it internally uses this header to check if the request is a multipart form request.

The issue can be reproduced locally using [AWS SAM](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-local-start-api.html) along with the code in the original issue.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
