### PR TITLE
Use `Header.Set` instead of `Header.Add`

### DIFF
--- a/core/request.go
+++ b/core/request.go
@@ -213,13 +213,13 @@ func addToHeader(req *http.Request, apiGwRequest events.APIGatewayProxyRequest) 
 		log.Println("Could not marshal stage variables for custom header")
 		return nil, err
 	}
-	req.Header.Add(APIGwStageVarsHeader, string(stageVars))
+	req.Header.Set(APIGwStageVarsHeader, string(stageVars))
 	apiGwContext, err := json.Marshal(apiGwRequest.RequestContext)
 	if err != nil {
 		log.Println("Could not Marshal API GW context for custom header")
 		return req, err
 	}
-	req.Header.Add(APIGwContextHeader, string(apiGwContext))
+	req.Header.Set(APIGwContextHeader, string(apiGwContext))
 	return req, nil
 }
 

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -217,6 +217,16 @@ var _ = Describe("RequestAccessor tests", func() {
 			// should fail because using header proxy method
 			Expect(ok).To(BeFalse())
 
+			// overwrite existing context header
+			contextRequestWithHeaders := getProxyRequest("orders", "GET")
+			contextRequestWithHeaders.RequestContext = getRequestContext()
+			contextRequestWithHeaders.Headers = map[string]string{core.APIGwContextHeader: `{"AccountID":"abc123"}`}
+			httpReq, err = accessor.ProxyEventToHTTPRequest(contextRequestWithHeaders)
+			Expect(err).To(BeNil())
+			headerContext, err = accessor.GetAPIGatewayContext(httpReq)
+			Expect(err).To(BeNil())
+			Expect(headerContext.AccountID).To(Equal("x"))
+
 			httpReq, err = accessor.EventToRequestWithContext(context.Background(), contextRequest)
 			Expect(err).To(BeNil())
 			proxyContext, ok = core.GetAPIGatewayContextFromContext(httpReq.Context())
@@ -263,6 +273,16 @@ var _ = Describe("RequestAccessor tests", func() {
 			Expect(stageVars["var2"]).ToNot(BeNil())
 			Expect("value1").To(Equal(stageVars["var1"]))
 			Expect("value2").To(Equal(stageVars["var2"]))
+
+			// overwrite existing stagevars header
+			varsRequestWithHeaders := getProxyRequest("orders", "GET")
+			varsRequestWithHeaders.StageVariables = getStageVariables()
+			varsRequestWithHeaders.Headers = map[string]string{core.APIGwStageVarsHeader: `{"var1":"abc123"}`}
+			httpReq, err = accessor.ProxyEventToHTTPRequest(varsRequestWithHeaders)
+			Expect(err).To(BeNil())
+			stageVars, err = accessor.GetAPIGatewayStageVars(httpReq)
+			Expect(err).To(BeNil())
+			Expect(stageVars["var1"]).To(Equal("value1"))
 
 			stageVars, ok := core.GetStageVarsFromContext(httpReq.Context())
 			// not present in context


### PR DESCRIPTION
 to prevent the context and stagevars values from being overwritten by the HTTP header in the request.

```
curl -H 'X-GoLambdaProxy-ApiGw-Context: {"AccountID":"abc123"}' https://xxxxx.execute-api.us-east-1.amazonaws.com/foo
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
