### PR TITLE
v2 HTTP API response header fix.

### DIFF
--- a/core/responsev2.go
+++ b/core/responsev2.go
@@ -100,8 +100,14 @@ func (r *ProxyResponseWriterV2) GetProxyResponse() (events.APIGatewayV2HTTPRespo
 		isBase64 = true
 	}
 
+	headers := make(map[string]string)
+	for k, _ := range r.headers {
+		headers[k] = r.headers.Get(k)
+	}
+
 	return events.APIGatewayV2HTTPResponse{
 		StatusCode:        r.status,
+		Headers:           headers,
 		MultiValueHeaders: http.Header(r.headers),
 		Body:              output,
 		IsBase64Encoded:   isBase64,


### PR DESCRIPTION
This fix is related to #60 and possibly #75.

*Description of changes:*

The value for `events.APIGatewayV2HTTPResponse.MultiValueHeaders` is not being used by API Gateway v2 HTTP API instances and thus the returned headers are not passed through to the client. This change adds the value of each header in `ProxyResponseWriterV2` to the `events.APIGatewayV2HTTPResponse.Headers` struct field.

- Extract v2 response headers from `ProxyResponseWriterV2.headers`.
- Include extracted headers in the returned `events.APIGatewayV2HTTPResponse`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
