### PR TITLE
Add support for ApiGateway V2 version for the gorilla/mux adapter

### DIFF
--- a/gorillamux/adapterv2.go
+++ b/gorillamux/adapterv2.go
@@ -1,0 +1,53 @@
+package gorillamux
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/awslabs/aws-lambda-go-api-proxy/core"
+	"github.com/gorilla/mux"
+)
+
+type GorillaMuxAdapterV2 struct {
+	core.RequestAccessorV2
+	router *mux.Router
+}
+
+func NewV2(router *mux.Router) *GorillaMuxAdapterV2 {
+	return &GorillaMuxAdapterV2{
+		router: router,
+	}
+}
+
+// Proxy receives an API Gateway proxy event, transforms it into an http.Request
+// object, and sends it to the mux.Router for routing.
+// It returns a proxy response object generated from the http.ResponseWriter.
+func (h *GorillaMuxAdapterV2) Proxy(event events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	req, err := h.ProxyEventToHTTPRequest(event)
+	return h.proxyInternal(req, err)
+}
+
+// ProxyWithContext receives context and an API Gateway proxy event,
+// transforms them into an http.Request object, and sends it to the mux.Router for routing.
+// It returns a proxy response object generated from the http.ResponseWriter.
+func (h *GorillaMuxAdapterV2) ProxyWithContext(ctx context.Context, event events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	req, err := h.EventToRequestWithContext(ctx, event)
+	return h.proxyInternal(req, err)
+}
+
+func (h *GorillaMuxAdapterV2) proxyInternal(req *http.Request, err error) (events.APIGatewayV2HTTPResponse, error) {
+	if err != nil {
+		return core.GatewayTimeoutV2(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
+	}
+
+	w := core.NewProxyResponseWriterV2()
+	h.router.ServeHTTP(http.ResponseWriter(w), req)
+
+	resp, err := w.GetProxyResponse()
+	if err != nil {
+		return core.GatewayTimeoutV2(), core.NewLoggedError("Error while generating proxy response: %v", err)
+	}
+
+	return resp, nil
+}

--- a/gorillamux/adapterv2_test.go
+++ b/gorillamux/adapterv2_test.go
@@ -1,0 +1,66 @@
+package gorillamux_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/awslabs/aws-lambda-go-api-proxy/gorillamux"
+	"github.com/gorilla/mux"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GorillaMuxAdapterV2 tests", func() {
+	Context("Simple ping request", func() {
+		It("Proxies the event correctly", func() {
+			homeHandler := func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Add("unfortunately-required-header", "")
+				fmt.Fprintf(w, "Home Page")
+			}
+
+			productsHandler := func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Add("unfortunately-required-header", "")
+				fmt.Fprintf(w, "Products Page")
+			}
+
+			r := mux.NewRouter()
+			r.HandleFunc("/", homeHandler)
+			r.HandleFunc("/products", productsHandler)
+
+			adapter := gorillamux.NewV2(r)
+
+			homePageReq := events.APIGatewayV2HTTPRequest{
+				RequestContext: events.APIGatewayV2HTTPRequestContext{
+					HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
+						Method: http.MethodGet,
+						Path:   "/",
+					},
+				},
+			}
+
+			homePageResp, homePageReqErr := adapter.ProxyWithContext(context.Background(), homePageReq)
+
+			Expect(homePageReqErr).To(BeNil())
+			Expect(homePageResp.StatusCode).To(Equal(200))
+			Expect(homePageResp.Body).To(Equal("Home Page"))
+
+			productsPageReq := events.APIGatewayV2HTTPRequest{
+				RequestContext: events.APIGatewayV2HTTPRequestContext{
+					HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
+						Method: http.MethodGet,
+						Path:   "/products",
+					},
+				},
+			}
+
+			productsPageResp, productsPageReqErr := adapter.Proxy(productsPageReq)
+
+			Expect(productsPageReqErr).To(BeNil())
+			Expect(productsPageResp.StatusCode).To(Equal(200))
+			Expect(productsPageResp.Body).To(Equal("Products Page"))
+		})
+	})
+})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Gorilla/mux adapter only supports API Gateway V1 Payloads. This PR adds an adapter v2 alongside the v1 version without breaking anything.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
