### PR TITLE
Automatic/passive switching between V1 and V2 API Gateway API requests and responses based on JSON marshal/unmarshal interfaces for Gorillia, & Cookies fixed for v2 & Tests fixed for V2 (wrong structure)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.out
 
 .vscode
+.idea
 vendor/*/
 gin/aws-lambda-go-api-proxy-gin
 core/aws-lambda-go-api-proxy-core

--- a/core/requestv2.go
+++ b/core/requestv2.go
@@ -164,6 +164,10 @@ func (r *RequestAccessorV2) EventToRequest(req events.APIGatewayV2HTTPRequest) (
 		return nil, err
 	}
 
+	for _, cookie := range req.Cookies {
+		httpRequest.Header.Add("Cookie", cookie)
+	}
+
 	for headerKey, headerValue := range req.Headers {
 		for _, val := range strings.Split(headerValue, ",") {
 			httpRequest.Header.Add(headerKey, strings.Trim(val, " "))

--- a/core/requestv2_test.go
+++ b/core/requestv2_test.go
@@ -320,6 +320,19 @@ var _ = Describe("RequestAccessorV2 tests", func() {
 			Expect(myCustomHost).To(Equal("http://" + httpReq.URL.Host))
 			os.Unsetenv(core.CustomHostVariable)
 		})
+
+		It("handles cookies okay", func() {
+			basicRequest := getProxyRequestV2("orders", "GET")
+			basicRequest.Cookies = []string{
+				"TestCookie=123",
+			}
+			accessor := core.RequestAccessorV2{}
+			httpReq, err := accessor.EventToRequestWithContext(context.Background(), basicRequest)
+			Expect(err).To(BeNil())
+			Expect(httpReq.Cookie("TestCookie")).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Value": Equal("123"),
+			})))
+		})
 	})
 })
 

--- a/core/requestv2_test.go
+++ b/core/requestv2_test.go
@@ -3,6 +3,7 @@ package core_test
 import (
 	"context"
 	"encoding/base64"
+	"github.com/onsi/gomega/gstruct"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -247,10 +248,10 @@ var _ = Describe("RequestAccessorV2 tests", func() {
 		})
 
 		It("Populates stage variables correctly", func() {
-			varsRequest := getProxyRequest("orders", "GET")
+			varsRequest := getProxyRequestV2("orders", "GET")
 			varsRequest.StageVariables = getStageVariables()
 
-			accessor := core.RequestAccessor{}
+			accessor := core.RequestAccessorV2{}
 			httpReq, err := accessor.ProxyEventToHTTPRequest(varsRequest)
 			Expect(err).To(BeNil())
 
@@ -262,7 +263,7 @@ var _ = Describe("RequestAccessorV2 tests", func() {
 			Expect("value1").To(Equal(stageVars["var1"]))
 			Expect("value2").To(Equal(stageVars["var2"]))
 
-			stageVars, ok := core.GetStageVarsFromContext(httpReq.Context())
+			stageVars, ok := core.GetStageVarsFromContextV2(httpReq.Context())
 			// not present in context
 			Expect(ok).To(BeFalse())
 
@@ -273,7 +274,7 @@ var _ = Describe("RequestAccessorV2 tests", func() {
 			// should not be in headers
 			Expect(err).ToNot(BeNil())
 
-			stageVars, ok = core.GetStageVarsFromContext(httpReq.Context())
+			stageVars, ok = core.GetStageVarsFromContextV2(httpReq.Context())
 			Expect(ok).To(BeTrue())
 			Expect(2).To(Equal(len(stageVars)))
 			Expect(stageVars["var1"]).ToNot(BeNil())
@@ -284,9 +285,9 @@ var _ = Describe("RequestAccessorV2 tests", func() {
 
 		It("Populates the default hostname correctly", func() {
 
-			basicRequest := getProxyRequest("orders", "GET")
-			basicRequest.RequestContext = getRequestContext()
-			accessor := core.RequestAccessor{}
+			basicRequest := getProxyRequestV2("orders", "GET")
+			basicRequest.RequestContext = getRequestContextV2()
+			accessor := core.RequestAccessorV2{}
 			httpReq, err := accessor.ProxyEventToHTTPRequest(basicRequest)
 			Expect(err).To(BeNil())
 
@@ -297,8 +298,8 @@ var _ = Describe("RequestAccessorV2 tests", func() {
 		It("Uses a custom hostname", func() {
 			myCustomHost := "http://my-custom-host.com"
 			os.Setenv(core.CustomHostVariable, myCustomHost)
-			basicRequest := getProxyRequest("orders", "GET")
-			accessor := core.RequestAccessor{}
+			basicRequest := getProxyRequestV2("orders", "GET")
+			accessor := core.RequestAccessorV2{}
 			httpReq, err := accessor.EventToRequestWithContext(context.Background(), basicRequest)
 			Expect(err).To(BeNil())
 
@@ -310,8 +311,8 @@ var _ = Describe("RequestAccessorV2 tests", func() {
 		It("Strips terminating / from hostname", func() {
 			myCustomHost := "http://my-custom-host.com"
 			os.Setenv(core.CustomHostVariable, myCustomHost+"/")
-			basicRequest := getProxyRequest("orders", "GET")
-			accessor := core.RequestAccessor{}
+			basicRequest := getProxyRequestV2("orders", "GET")
+			accessor := core.RequestAccessorV2{}
 			httpReq, err := accessor.EventToRequestWithContext(context.Background(), basicRequest)
 			Expect(err).To(BeNil())
 

--- a/core/responsev2.go
+++ b/core/responsev2.go
@@ -102,8 +102,13 @@ func (r *ProxyResponseWriterV2) GetProxyResponse() (events.APIGatewayV2HTTPRespo
 	}
 
 	headers := make(map[string]string)
+	cookies := make([]string, 0)
 
 	for headerKey, headerValue := range http.Header(r.headers) {
+		if strings.EqualFold("set-cookie", headerKey) {
+			cookies = append(cookies, headerValue...)
+			continue
+		}
 		headers[headerKey] = strings.Join(headerValue, ",")
 	}
 
@@ -112,5 +117,6 @@ func (r *ProxyResponseWriterV2) GetProxyResponse() (events.APIGatewayV2HTTPRespo
 		Headers:         headers,
 		Body:            output,
 		IsBase64Encoded: isBase64,
+		Cookies:         cookies,
 	}, nil
 }

--- a/core/responsev2_test.go
+++ b/core/responsev2_test.go
@@ -159,14 +159,26 @@ var _ = Describe("ResponseWriterV2 tests", func() {
 
 		It("Writes multi-value headers correctly", func() {
 			response := NewProxyResponseWriterV2()
+			response.Header().Add("Accepts", "foobar")
+			response.Header().Add("Accepts", "barfoo")
+			response.Write([]byte("hello"))
+			proxyResponse, err := response.GetProxyResponse()
+			Expect(err).To(BeNil())
+
+			Expect(2).To(Equal(len(proxyResponse.Headers)))
+			Expect("foobar,barfoo").To(Equal(proxyResponse.Headers["Accepts"]))
+		})
+
+		It("Writes cookies correctly", func() {
+			response := NewProxyResponseWriterV2()
 			response.Header().Add("Set-Cookie", "csrftoken=foobar")
 			response.Header().Add("Set-Cookie", "session_id=barfoo")
 			response.Write([]byte("hello"))
 			proxyResponse, err := response.GetProxyResponse()
 			Expect(err).To(BeNil())
 
-			Expect(2).To(Equal(len(proxyResponse.Headers)))
-			Expect("csrftoken=foobar,session_id=barfoo").To(Equal(proxyResponse.Headers["Set-Cookie"]))
+			Expect(2).To(Equal(len(proxyResponse.Cookies)))
+			Expect(strings.Split("csrftoken=foobar,session_id=barfoo", ",")).To(Equal(proxyResponse.Cookies))
 		})
 	})
 

--- a/core/switchablerequest.go
+++ b/core/switchablerequest.go
@@ -1,0 +1,72 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/aws/aws-lambda-go/events"
+)
+
+type SwitchableAPIGatewayRequest struct {
+	v interface{} // v is Always nil, or a pointer of APIGatewayProxyRequest or APIGatewayV2HTTPRequest
+}
+
+// NewSwitchableAPIGatewayRequestV1 creates a new SwitchableAPIGatewayRequest from APIGatewayProxyRequest
+func NewSwitchableAPIGatewayRequestV1(v *events.APIGatewayProxyRequest) *SwitchableAPIGatewayRequest {
+	return &SwitchableAPIGatewayRequest{
+		v: v,
+	}
+}
+// NewSwitchableAPIGatewayRequestV2 creates a new SwitchableAPIGatewayRequest from APIGatewayV2HTTPRequest
+func NewSwitchableAPIGatewayRequestV2(v *events.APIGatewayV2HTTPRequest) *SwitchableAPIGatewayRequest {
+	return &SwitchableAPIGatewayRequest{
+		v: v,
+	}
+}
+
+// MarshalJSON is a pass through serialization
+func (s *SwitchableAPIGatewayRequest) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.v)
+}
+
+// UnmarshalJSON is a switching serialization based on the presence of fields in the
+// source JSON, multiValueQueryStringParameters for APIGatewayProxyRequest and rawQueryString for
+// APIGatewayV2HTTPRequest.
+func (s *SwitchableAPIGatewayRequest) UnmarshalJSON(b []byte) error {
+	delta := map[string]json.RawMessage{}
+	if err := json.Unmarshal(b, &delta); err != nil {
+		return err
+	}
+	_, v1test := delta["multiValueQueryStringParameters"]
+	_, v2test := delta["rawQueryString"]
+	s.v = nil
+	if v1test && !v2test {
+		s.v = &events.APIGatewayProxyRequest{}
+	} else if !v1test && v2test {
+		s.v = &events.APIGatewayV2HTTPRequest{}
+	} else {
+		return errors.New("unable to determine request version")
+	}
+	return json.Unmarshal(b, s.v)
+}
+
+// Version1 returns the contained events.APIGatewayProxyRequest or nil
+func (s *SwitchableAPIGatewayRequest) Version1() *events.APIGatewayProxyRequest {
+	switch v := s.v.(type) {
+	case *events.APIGatewayProxyRequest:
+		return v
+	case events.APIGatewayProxyRequest:
+		return &v
+	}
+	return nil
+}
+
+// Version2 returns the contained events.APIGatewayV2HTTPRequest or nil
+func (s *SwitchableAPIGatewayRequest) Version2() *events.APIGatewayV2HTTPRequest {
+	switch v := s.v.(type) {
+	case *events.APIGatewayV2HTTPRequest:
+		return v
+	case events.APIGatewayV2HTTPRequest:
+		return &v
+	}
+	return nil
+}

--- a/core/switchablerequest_test.go
+++ b/core/switchablerequest_test.go
@@ -1,0 +1,74 @@
+package core
+
+import (
+	"encoding/json"
+	"github.com/aws/aws-lambda-go/events"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SwitchableAPIGatewayRequest", func() {
+	Context("Serialization", func() {
+		It("v1 serialized okay", func() {
+			e := NewSwitchableAPIGatewayRequestV1(&events.APIGatewayProxyRequest{
+				MultiValueQueryStringParameters: map[string][]string{},
+			})
+			b, err := json.Marshal(e)
+			Expect(err).To(BeNil())
+			m := map[string]interface{}{}
+			err = json.Unmarshal(b, &m)
+			Expect(err).To(BeNil())
+			Expect(m["multiValueQueryStringParameters"]).To(Equal(map[string]interface {}{}))
+			Expect(m["body"]).To(Equal(""))
+		})
+		It("v2 serialized okay", func() {
+			e := NewSwitchableAPIGatewayRequestV2(&events.APIGatewayV2HTTPRequest{})
+			b, err := json.Marshal(e)
+			Expect(err).To(BeNil())
+			m := map[string]interface{}{}
+			err = json.Unmarshal(b, &m)
+			Expect(err).To(BeNil())
+			Expect(m["rawQueryString"]).To(Equal(""))
+			Expect(m["isBase64Encoded"]).To(Equal(false))
+		})
+	})
+	Context("Deserialization", func() {
+		It("v1 deserialized okay", func() {
+			input := &events.APIGatewayProxyRequest{
+				Body:       "234",
+				MultiValueQueryStringParameters: map[string][]string{
+					"Test": []string{ "Value1", "Value2", },
+				},
+			}
+			b, _ := json.Marshal(input)
+			s := SwitchableAPIGatewayRequest{}
+			err := s.UnmarshalJSON(b)
+			Expect(err).To(BeNil())
+			Expect(s.Version2()).To(BeNil())
+			Expect(s.Version1()).To(BeEquivalentTo(input))
+		})
+		It("v2 deserialized okay", func() {
+			input := &events.APIGatewayV2HTTPRequest{
+				IsBase64Encoded:       true,
+				RawQueryString: "a=b&c=d",
+			}
+			b, _ := json.Marshal(input)
+			s := SwitchableAPIGatewayRequest{}
+			err := s.UnmarshalJSON(b)
+			Expect(err).To(BeNil())
+			Expect(s.Version1()).To(BeNil())
+			Expect(s.Version2()).To(BeEquivalentTo(input))
+		})
+	})})
+
+func getProxyRequestV2(path string, method string) events.APIGatewayV2HTTPRequest {
+	return events.APIGatewayV2HTTPRequest{
+		RequestContext: events.APIGatewayV2HTTPRequestContext{
+			HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
+				Path:   path,
+				Method: method,
+			},
+		},
+		RawPath: path,
+	}
+}

--- a/core/switchableresponse.go
+++ b/core/switchableresponse.go
@@ -1,0 +1,77 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/aws/aws-lambda-go/events"
+)
+
+// SwitchableAPIGatewayResponse is a container for an APIGatewayProxyResponse or an APIGatewayV2HTTPResponse object which
+// handles serialization and deserialization and switching between the entities based on the presence of fields in the
+// source JSON, multiValueQueryStringParameters for APIGatewayProxyResponse and rawQueryString for
+// APIGatewayV2HTTPResponse. It also provides some simple switching functions (wrapped type switching.)
+type SwitchableAPIGatewayResponse struct {
+	v interface{}
+}
+
+// NewSwitchableAPIGatewayResponseV1 creates a new SwitchableAPIGatewayResponse from APIGatewayProxyResponse
+func NewSwitchableAPIGatewayResponseV1(v *events.APIGatewayProxyResponse) *SwitchableAPIGatewayResponse {
+	return &SwitchableAPIGatewayResponse{
+		v: v,
+	}
+}
+
+// NewSwitchableAPIGatewayResponseV2 creates a new SwitchableAPIGatewayResponse from APIGatewayV2HTTPResponse
+func NewSwitchableAPIGatewayResponseV2(v *events.APIGatewayV2HTTPResponse) *SwitchableAPIGatewayResponse {
+	return &SwitchableAPIGatewayResponse{
+		v: v,
+	}
+}
+
+// MarshalJSON is a pass through serialization
+func (s *SwitchableAPIGatewayResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.v)
+}
+
+// UnmarshalJSON is a switching serialization based on the presence of fields in the
+// source JSON, statusCode to verify that it's either APIGatewayProxyResponse or APIGatewayV2HTTPResponse and then
+// rawQueryString for to determine if it is APIGatewayV2HTTPResponse or not.
+func (s *SwitchableAPIGatewayResponse) UnmarshalJSON(b []byte) error {
+	delta := map[string]json.RawMessage{}
+	if err := json.Unmarshal(b, &delta); err != nil {
+		return err
+	}
+	_, test := delta["statusCode"]
+	_, v2test := delta["cookies"]
+	s.v = nil
+	if test && !v2test {
+		s.v = &events.APIGatewayProxyResponse{}
+	} else if test && v2test {
+		s.v = &events.APIGatewayV2HTTPResponse{}
+	} else {
+		return errors.New("unable to determine response version")
+	}
+	return json.Unmarshal(b, s.v)
+}
+
+// Version1 returns the contained events.APIGatewayProxyResponse or nil
+func (s *SwitchableAPIGatewayResponse) Version1() *events.APIGatewayProxyResponse {
+	switch v := s.v.(type) {
+	case *events.APIGatewayProxyResponse:
+		return v
+	case events.APIGatewayProxyResponse:
+		return &v
+	}
+	return nil
+}
+
+// Version2 returns the contained events.APIGatewayV2HTTPResponse or nil
+func (s *SwitchableAPIGatewayResponse) Version2() *events.APIGatewayV2HTTPResponse {
+	switch v := s.v.(type) {
+	case *events.APIGatewayV2HTTPResponse:
+		return v
+	case events.APIGatewayV2HTTPResponse:
+		return &v
+	}
+	return nil
+}

--- a/core/switchableresponse_test.go
+++ b/core/switchableresponse_test.go
@@ -1,0 +1,61 @@
+package core
+
+import (
+	"encoding/json"
+	"github.com/aws/aws-lambda-go/events"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SwitchableAPIGatewayResponse", func() {
+	Context("Serialization", func() {
+		It("v1 serialized okay", func() {
+			e := NewSwitchableAPIGatewayResponseV1(&events.APIGatewayProxyResponse{})
+			b, err := json.Marshal(e)
+			Expect(err).To(BeNil())
+			m := map[string]interface{}{}
+			err = json.Unmarshal(b, &m)
+			Expect(err).To(BeNil())
+			Expect(m["statusCode"]).To(Equal(0.0))
+			Expect(m["body"]).To(Equal(""))
+		})
+		It("v2 serialized okay", func() {
+			e := NewSwitchableAPIGatewayResponseV2(&events.APIGatewayV2HTTPResponse{})
+			b, err := json.Marshal(e)
+			Expect(err).To(BeNil())
+			m := map[string]interface{}{}
+			err = json.Unmarshal(b, &m)
+			Expect(err).To(BeNil())
+			Expect(m["statusCode"]).To(Equal(0.0))
+			Expect(m["body"]).To(Equal(""))
+		})
+	})
+	Context("Deserialization", func() {
+		It("v1 deserialized okay", func() {
+			input := &events.APIGatewayProxyResponse{
+				StatusCode: 123,
+				Body:       "234",
+			}
+			b, _ := json.Marshal(input)
+			s := SwitchableAPIGatewayResponse{}
+			err := s.UnmarshalJSON(b)
+			Expect(err).To(BeNil())
+			Expect(s.Version2()).To(BeNil())
+			Expect(s.Version1()).To(BeEquivalentTo(input))
+		})
+		It("v2 deserialized okay", func() {
+			input := &events.APIGatewayV2HTTPResponse{
+				StatusCode: 123,
+				Body:       "234",
+				Cookies:    []string{"4", "5"},
+			}
+			b, _ := json.Marshal(input)
+			s := SwitchableAPIGatewayResponse{}
+			err := s.UnmarshalJSON(b)
+			Expect(err).To(BeNil())
+			Expect(s.Version1()).To(BeNil())
+			Expect(s.Version2()).To(BeEquivalentTo(input))
+		})
+	})
+})
+

--- a/gorillamux/adapter.go
+++ b/gorillamux/adapter.go
@@ -2,15 +2,16 @@ package gorillamux
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
-	"github.com/aws/aws-lambda-go/events"
 	"github.com/awslabs/aws-lambda-go-api-proxy/core"
 	"github.com/gorilla/mux"
 )
 
 type GorillaMuxAdapter struct {
-	core.RequestAccessor
+	RequestAccessor core.RequestAccessor
+	RequestAccessorV2 core.RequestAccessorV2
 	router *mux.Router
 }
 
@@ -20,25 +21,40 @@ func New(router *mux.Router) *GorillaMuxAdapter {
 	}
 }
 
-// Proxy receives an API Gateway proxy event, transforms it into an http.Request
+// Proxy receives an API Gateway proxy event or API Gateway V2 event, transforms it into an http.Request
 // object, and sends it to the mux.Router for routing.
 // It returns a proxy response object generated from the http.ResponseWriter.
-func (h *GorillaMuxAdapter) Proxy(event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	req, err := h.ProxyEventToHTTPRequest(event)
-	return h.proxyInternal(req, err)
+func (h *GorillaMuxAdapter) Proxy(event core.SwitchableAPIGatewayRequest) (*core.SwitchableAPIGatewayResponse, error) {
+	if event.Version1() != nil {
+		req, err := h.RequestAccessor.ProxyEventToHTTPRequest(*event.Version1())
+		return h.proxyInternal(req, err)
+	} else if event.Version2() != nil {
+		req, err := h.RequestAccessorV2.ProxyEventToHTTPRequest(*event.Version2())
+		return h.proxyInternalV2(req, err)
+	} else {
+		return &core.SwitchableAPIGatewayResponse{}, core.NewLoggedError("Could not convert proxy event to request: %v", errors.New("Unable to determine version "))
+	}
 }
 
-// ProxyWithContext receives context and an API Gateway proxy event,
+// ProxyWithContext receives context and an API Gateway proxy event or API Gateway V2 event,
 // transforms them into an http.Request object, and sends it to the mux.Router for routing.
 // It returns a proxy response object generated from the http.ResponseWriter.
-func (h *GorillaMuxAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	req, err := h.EventToRequestWithContext(ctx, event)
-	return h.proxyInternal(req, err)
+func (h *GorillaMuxAdapter) ProxyWithContext(ctx context.Context, event core.SwitchableAPIGatewayRequest) (*core.SwitchableAPIGatewayResponse, error) {
+	if event.Version1() != nil {
+		req, err := h.RequestAccessor.EventToRequestWithContext(ctx, *event.Version1())
+		return h.proxyInternal(req, err)
+	} else if event.Version2() != nil {
+		req, err := h.RequestAccessorV2.EventToRequestWithContext(ctx, *event.Version2())
+		return h.proxyInternalV2(req, err)
+	} else {
+		return &core.SwitchableAPIGatewayResponse{}, core.NewLoggedError("Could not convert proxy event to request: %v", errors.New("Unable to determine version "))
+	}
 }
 
-func (h *GorillaMuxAdapter) proxyInternal(req *http.Request, err error) (events.APIGatewayProxyResponse, error) {
+func (h *GorillaMuxAdapter) proxyInternal(req *http.Request, err error) (*core.SwitchableAPIGatewayResponse, error) {
 	if err != nil {
-		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
+		timeout := core.GatewayTimeout()
+		return core.NewSwitchableAPIGatewayResponseV1(&timeout), core.NewLoggedError("Could not convert proxy event to request: %v", err)
 	}
 
 	w := core.NewProxyResponseWriter()
@@ -46,8 +62,27 @@ func (h *GorillaMuxAdapter) proxyInternal(req *http.Request, err error) (events.
 
 	resp, err := w.GetProxyResponse()
 	if err != nil {
-		return core.GatewayTimeout(), core.NewLoggedError("Error while generating proxy response: %v", err)
+		timeout := core.GatewayTimeout()
+		return core.NewSwitchableAPIGatewayResponseV1(&timeout), core.NewLoggedError("Error while generating proxy response: %v", err)
 	}
 
-	return resp, nil
+	return core.NewSwitchableAPIGatewayResponseV1(&resp), nil
+}
+
+func (h *GorillaMuxAdapter) proxyInternalV2(req *http.Request, err error) (*core.SwitchableAPIGatewayResponse, error) {
+	if err != nil {
+		timeout := core.GatewayTimeoutV2()
+		return core.NewSwitchableAPIGatewayResponseV2(&timeout), core.NewLoggedError("Could not convert proxy event to request: %v", err)
+	}
+
+	w := core.NewProxyResponseWriterV2()
+	h.router.ServeHTTP(http.ResponseWriter(w), req)
+
+	resp, err := w.GetProxyResponse()
+	if err != nil {
+		timeout := core.GatewayTimeoutV2()
+		return core.NewSwitchableAPIGatewayResponseV2(&timeout), core.NewLoggedError("Error while generating proxy response: %v", err)
+	}
+
+	return core.NewSwitchableAPIGatewayResponseV2(&resp), nil
 }

--- a/gorillamux/adapter_test.go
+++ b/gorillamux/adapter_test.go
@@ -3,6 +3,7 @@ package gorillamux_test
 import (
 	"context"
 	"fmt"
+	"github.com/awslabs/aws-lambda-go-api-proxy/core"
 	"net/http"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -14,7 +15,7 @@ import (
 )
 
 var _ = Describe("GorillaMuxAdapter tests", func() {
-	Context("Simple ping request", func() {
+	Context("Simple ping request with v1", func() {
 		It("Proxies the event correctly", func() {
 			homeHandler := func(w http.ResponseWriter, req *http.Request) {
 				w.Header().Add("unfortunately-required-header", "")
@@ -37,22 +38,71 @@ var _ = Describe("GorillaMuxAdapter tests", func() {
 				HTTPMethod: "GET",
 			}
 
-			homePageResp, homePageReqErr := adapter.ProxyWithContext(context.Background(), homePageReq)
+			homePageResp, homePageReqErr := adapter.ProxyWithContext(context.Background(), *core.NewSwitchableAPIGatewayRequestV1(&homePageReq))
 
 			Expect(homePageReqErr).To(BeNil())
-			Expect(homePageResp.StatusCode).To(Equal(200))
-			Expect(homePageResp.Body).To(Equal("Home Page"))
+			Expect(homePageResp.Version1().StatusCode).To(Equal(200))
+			Expect(homePageResp.Version1().Body).To(Equal("Home Page"))
 
 			productsPageReq := events.APIGatewayProxyRequest{
 				Path:       "/products",
 				HTTPMethod: "GET",
 			}
 
-			productsPageResp, productsPageReqErr := adapter.Proxy(productsPageReq)
+			productsPageResp, productsPageReqErr := adapter.Proxy(*core.NewSwitchableAPIGatewayRequestV1(&productsPageReq))
 
 			Expect(productsPageReqErr).To(BeNil())
-			Expect(productsPageResp.StatusCode).To(Equal(200))
-			Expect(productsPageResp.Body).To(Equal("Products Page"))
+			Expect(productsPageResp.Version1().StatusCode).To(Equal(200))
+			Expect(productsPageResp.Version1().Body).To(Equal("Products Page"))
+		})
+	})
+
+	Context("Simple ping request with v2", func() {
+		It("Proxies the event correctly", func() {
+			homeHandler := func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Add("unfortunately-required-header", "")
+				fmt.Fprintf(w, "Home Page")
+			}
+
+			productsHandler := func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Add("unfortunately-required-header", "")
+				fmt.Fprintf(w, "Products Page")
+			}
+
+			r := mux.NewRouter()
+			r.HandleFunc("/", homeHandler)
+			r.HandleFunc("/products", productsHandler)
+
+			adapter := gorillamux.New(r)
+
+			homePageReq := getProxyRequestV2("/", "GET")
+
+			homePageResp, homePageReqErr := adapter.ProxyWithContext(context.Background(), *core.NewSwitchableAPIGatewayRequestV2(&homePageReq))
+
+			Expect(homePageReqErr).To(BeNil())
+			Expect(homePageResp.Version2().StatusCode).To(Equal(200))
+			Expect(homePageResp.Version2().Body).To(Equal("Home Page"))
+
+			productsPageReq := getProxyRequestV2("/products", "GET")
+
+			productsPageResp, productsPageReqErr := adapter.Proxy(*core.NewSwitchableAPIGatewayRequestV2(&productsPageReq))
+
+			Expect(productsPageReqErr).To(BeNil())
+			Expect(productsPageResp.Version2().StatusCode).To(Equal(200))
+			Expect(productsPageResp.Version2().Body).To(Equal("Products Page"))
 		})
 	})
 })
+
+func getProxyRequestV2(path string, method string) events.APIGatewayV2HTTPRequest {
+	return events.APIGatewayV2HTTPRequest{
+		RequestContext: events.APIGatewayV2HTTPRequestContext{
+			HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
+				Path:   path,
+				Method: method,
+			},
+		},
+		RawPath: path,
+	}
+}
+


### PR DESCRIPTION
This is an attempt at producing an interface that automatically switches between V1 and V2 API strctures based on the presense of keys in the request object, for gorillia mux.

It adds 2 new structures:
* `SwitchableAPIGatewayRequest`
* `SwitchableAPIGatewayResponse`

Which implement:
```
type Unmarshaler interface {
	UnmarshalJSON([]byte) error
}
```
and
```
type Marshaler interface {
	MarshalJSON() ([]byte, error)
}
```

Then select `GorillaMuxAdapter` into 3 different code paths:
1. Version1 Unmarshal successful
2. Version2 Unmarshal successful
3. Failed to match event

Some of the tests were using the wrong stucture.

Cookies were not handled correctly for V2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
