### PR TITLE
fix EventToRequestWithContext doesn't populat header for APIGatewayProxyRequestContext

### DIFF
--- a/core/request.go
+++ b/core/request.go
@@ -124,7 +124,7 @@ func (r *RequestAccessor) EventToRequestWithContext(ctx context.Context, req eve
 		log.Println(err)
 		return nil, err
 	}
-	return addToContext(ctx, httpRequest, req), nil
+	return addToHeader(addToContext(ctx, httpRequest, req), req)
 }
 
 // EventToRequest converts an API Gateway proxy event into an http.Request object.


### PR DESCRIPTION
…oxyRequestContext

*Issue #, if available:*

*Description of changes:*
The method EventToRequestWithContext forget to populate APIGatewayProxyRequestContext to the header of httprequest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
