### PR TITLE
Support v2 payloads for `httpadapter`

### DIFF
--- a/handlerfunc/adapter.go
+++ b/handlerfunc/adapter.go
@@ -1,52 +1,13 @@
 package handlerfunc
 
 import (
-	"context"
 	"net/http"
 
-	"github.com/aws/aws-lambda-go/events"
-	"github.com/awslabs/aws-lambda-go-api-proxy/core"
+	"github.com/awslabs/aws-lambda-go-api-proxy/httpadapter"
 )
 
-type HandlerFuncAdapter struct {
-	core.RequestAccessor
-	handlerFunc http.HandlerFunc
-}
+type HandlerFuncAdapter = httpadapter.HandlerAdapter
 
 func New(handlerFunc http.HandlerFunc) *HandlerFuncAdapter {
-	return &HandlerFuncAdapter{
-		handlerFunc: handlerFunc,
-	}
-}
-
-// Proxy receives an API Gateway proxy event, transforms it into an http.Request
-// object, and sends it to the http.HandlerFunc for routing.
-// It returns a proxy response object generated from the http.ResponseWriter.
-func (h *HandlerFuncAdapter) Proxy(event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	req, err := h.ProxyEventToHTTPRequest(event)
-	return h.proxyInternal(req, err)
-}
-
-// ProxyWithContext receives context and an API Gateway proxy event,
-// transforms them into an http.Request object, and sends it to the http.HandlerFunc for routing.
-// It returns a proxy response object generated from the http.ResponseWriter.
-func (h *HandlerFuncAdapter) ProxyWithContext(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	req, err := h.EventToRequestWithContext(ctx, event)
-	return h.proxyInternal(req, err)
-}
-
-func (h *HandlerFuncAdapter) proxyInternal(req *http.Request, err error) (events.APIGatewayProxyResponse, error) {
-	if err != nil {
-		return core.GatewayTimeout(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
-	}
-
-	w := core.NewProxyResponseWriter()
-	h.handlerFunc.ServeHTTP(http.ResponseWriter(w), req)
-
-	resp, err := w.GetProxyResponse()
-	if err != nil {
-		return core.GatewayTimeout(), core.NewLoggedError("Error while generating proxy response: %v", err)
-	}
-
-	return resp, nil
+	return httpadapter.New(handlerFunc)
 }

--- a/handlerfunc/adapterv2.go
+++ b/handlerfunc/adapterv2.go
@@ -1,52 +1,13 @@
 package handlerfunc
 
 import (
-	"context"
 	"net/http"
 
-	"github.com/aws/aws-lambda-go/events"
-	"github.com/awslabs/aws-lambda-go-api-proxy/core"
+	"github.com/awslabs/aws-lambda-go-api-proxy/httpadapter"
 )
 
-type HandlerFuncAdapterV2 struct {
-	core.RequestAccessorV2
-	handlerFunc http.HandlerFunc
-}
+type HandlerFuncAdapterV2 = httpadapter.HandlerAdapterV2
 
 func NewV2(handlerFunc http.HandlerFunc) *HandlerFuncAdapterV2 {
-	return &HandlerFuncAdapterV2{
-		handlerFunc: handlerFunc,
-	}
-}
-
-// Proxy receives an API Gateway proxy event, transforms it into an http.Request
-// object, and sends it to the http.HandlerFunc for routing.
-// It returns a proxy response object generated from the http.ResponseWriter.
-func (h *HandlerFuncAdapterV2) Proxy(event events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
-	req, err := h.ProxyEventToHTTPRequest(event)
-	return h.proxyInternal(req, err)
-}
-
-// ProxyWithContext receives context and an API Gateway proxy event,
-// transforms them into an http.Request object, and sends it to the http.HandlerFunc for routing.
-// It returns a proxy response object generated from the http.ResponseWriter.
-func (h *HandlerFuncAdapterV2) ProxyWithContext(ctx context.Context, event events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
-	req, err := h.EventToRequestWithContext(ctx, event)
-	return h.proxyInternal(req, err)
-}
-
-func (h *HandlerFuncAdapterV2) proxyInternal(req *http.Request, err error) (events.APIGatewayV2HTTPResponse, error) {
-	if err != nil {
-		return core.GatewayTimeoutV2(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
-	}
-
-	w := core.NewProxyResponseWriterV2()
-	h.handlerFunc.ServeHTTP(http.ResponseWriter(w), req)
-
-	resp, err := w.GetProxyResponse()
-	if err != nil {
-		return core.GatewayTimeoutV2(), core.NewLoggedError("Error while generating proxy response: %v", err)
-	}
-
-	return resp, nil
+	return httpadapter.NewV2(handlerFunc)
 }

--- a/httpadapter/adapterv2.go
+++ b/httpadapter/adapterv2.go
@@ -1,0 +1,52 @@
+package httpadapter
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/awslabs/aws-lambda-go-api-proxy/core"
+)
+
+type HandlerAdapterV2 struct {
+	core.RequestAccessorV2
+	handler http.Handler
+}
+
+func NewV2(handler http.Handler) *HandlerAdapterV2 {
+	return &HandlerAdapterV2{
+		handler: handler,
+	}
+}
+
+// Proxy receives an API Gateway proxy event, transforms it into an http.Request
+// object, and sends it to the http.HandlerFunc for routing.
+// It returns a proxy response object generated from the http.ResponseWriter.
+func (h *HandlerAdapterV2) Proxy(event events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	req, err := h.ProxyEventToHTTPRequest(event)
+	return h.proxyInternal(req, err)
+}
+
+// ProxyWithContext receives context and an API Gateway proxy event,
+// transforms them into an http.Request object, and sends it to the http.Handler for routing.
+// It returns a proxy response object generated from the http.ResponseWriter.
+func (h *HandlerAdapterV2) ProxyWithContext(ctx context.Context, event events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	req, err := h.EventToRequestWithContext(ctx, event)
+	return h.proxyInternal(req, err)
+}
+
+func (h *HandlerAdapterV2) proxyInternal(req *http.Request, err error) (events.APIGatewayV2HTTPResponse, error) {
+	if err != nil {
+		return core.GatewayTimeoutV2(), core.NewLoggedError("Could not convert proxy event to request: %v", err)
+	}
+
+	w := core.NewProxyResponseWriterV2()
+	h.handler.ServeHTTP(http.ResponseWriter(w), req)
+
+	resp, err := w.GetProxyResponse()
+	if err != nil {
+		return core.GatewayTimeoutV2(), core.NewLoggedError("Error while generating proxy response: %v", err)
+	}
+
+	return resp, nil
+}

--- a/httpadapter/adapterv2_test.go
+++ b/httpadapter/adapterv2_test.go
@@ -1,0 +1,48 @@
+package httpadapter_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/awslabs/aws-lambda-go-api-proxy/httpadapter"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("HandlerFuncAdapter tests", func() {
+	Context("Simple ping request", func() {
+		It("Proxies the event correctly", func() {
+			log.Println("Starting test")
+
+			var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Add("unfortunately-required-header", "")
+				fmt.Fprintf(w, "Go Lambda!!")
+			})
+
+			adapter := httpadapter.NewV2(handler)
+
+			req := events.APIGatewayV2HTTPRequest{
+				RequestContext: events.APIGatewayV2HTTPRequestContext{
+					HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
+						Method: http.MethodGet,
+						Path:   "/ping",
+					},
+				},
+			}
+
+			resp, err := adapter.ProxyWithContext(context.Background(), req)
+
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+
+			resp, err = adapter.Proxy(req)
+
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+		})
+	})
+})


### PR DESCRIPTION
https://github.com/awslabs/aws-lambda-go-api-proxy/pull/80 implemented support for `handlerfunc` but not `httpadapter`.

This provides an equivalent implementation to `handlerfunc.HandlerFuncAdapterV2` that will proxy `events.APIGatewayV2HTTPRequest` to a `http.Handler`.

A `http.HandlerFunc` implements the `http.Handler` interface so I've implemented `handlerfunc` in terms of `httpadapter`. This will avoid implementation drift. To avoid breaking backwards compatibility, this uses type aliases and preserves the `handlerfunc.New` and `handlerfunc.NewV2` methods.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
