### PR TITLE
bump echo to 4.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/kataras/golog v0.0.18 // indirect
 	github.com/kataras/iris/v12 v12.1.8
-	github.com/labstack/echo/v4 v4.1.17
+	github.com/labstack/echo/v4 v4.2.0
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.16 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect


### PR DESCRIPTION
https://security.snyk.io/vuln/SNYK-GOLANG-GITHUBCOMLABSTACKECHO-1050889

*Issue #, if available:*

*Description of changes:*
Hi, I am requesting we bump the version of echo/v4 to mitigate a directory traversal vuln.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
