### PR TITLE
chiadapter package documentation: fix typo

### DIFF
--- a/chi/adapter.go
+++ b/chi/adapter.go
@@ -1,4 +1,4 @@
-// Packge chilambda add Chi support for the aws-severless-go-api library.
+// Package chiadapter add Chi support for the aws-severless-go-api library.
 // Uses the core package behind the scenes and exposes the New method to
 // get a new instance and Proxy method to send request to the Chi mux.
 package chiadapter


### PR DESCRIPTION
*Description of changes:*

I've found a small typo in the `chiadapter` package documentation and fixed it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
