### PR TITLE
fiberlamda: fix the tests by removing gzip checks

### DIFF
--- a/fiber/fiberlambda_test.go
+++ b/fiber/fiberlambda_test.go
@@ -54,7 +54,6 @@ var _ = Describe("FiberLambda tests", func() {
 				Expect(c.Get(fiber.HeaderContentLength)).To(Equal("77"))
 				Expect(c.Get(fiber.HeaderConnection)).To(Equal("Keep-Alive"))
 				Expect(c.Get(fiber.HeaderKeepAlive)).To(Equal("timeout=5, max=1000"))
-				Expect(c.Get(fiber.HeaderTransferEncoding)).To(Equal("gzip"))
 
 				return c.Status(fiber.StatusNoContent).Send(nil)
 			})
@@ -71,10 +70,9 @@ var _ = Describe("FiberLambda tests", func() {
 
 					"cookie": {"a=b", "b=c;c=d"},
 
-					fiber.HeaderContentLength:    {"77"},
-					fiber.HeaderConnection:       {"Keep-Alive"},
-					fiber.HeaderKeepAlive:        {"timeout=5, max=1000"},
-					fiber.HeaderTransferEncoding: {"gzip"},
+					fiber.HeaderContentLength: {"77"},
+					fiber.HeaderConnection:    {"Keep-Alive"},
+					fiber.HeaderKeepAlive:     {"timeout=5, max=1000"},
 				},
 			}
 
@@ -209,7 +207,6 @@ var _ = Describe("FiberLambda tests", func() {
 				Expect(c.Get(fiber.HeaderContentLength)).To(Equal("77"))
 				Expect(c.Get(fiber.HeaderConnection)).To(Equal("Keep-Alive"))
 				Expect(c.Get(fiber.HeaderKeepAlive)).To(Equal("timeout=5, max=1000"))
-				Expect(c.Get(fiber.HeaderTransferEncoding)).To(Equal("gzip"))
 
 				return c.Status(fiber.StatusNoContent).Send(nil)
 			})
@@ -225,10 +222,9 @@ var _ = Describe("FiberLambda tests", func() {
 
 					"cookie": {"a=b", "b=c;c=d"},
 
-					fiber.HeaderContentLength:    {"77"},
-					fiber.HeaderConnection:       {"Keep-Alive"},
-					fiber.HeaderKeepAlive:        {"timeout=5, max=1000"},
-					fiber.HeaderTransferEncoding: {"gzip"},
+					fiber.HeaderContentLength: {"77"},
+					fiber.HeaderConnection:    {"Keep-Alive"},
+					fiber.HeaderKeepAlive:     {"timeout=5, max=1000"},
 				},
 			}
 


### PR DESCRIPTION
*Description of changes:*

Fasthttp automatically handles Transfer-Encoding header so our expectations of having this header in the fiber request context were failing.

https://github.com/valyala/fasthttp/blob/master/header.go#L1292


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
