### PR TITLE
feat: client address (ip) in the http request directly

### DIFF
--- a/core/request.go
+++ b/core/request.go
@@ -190,6 +190,8 @@ func (r *RequestAccessor) EventToRequest(req events.APIGatewayProxyRequest) (*ht
 		return nil, err
 	}
 
+	httpRequest.RemoteAddr = req.RequestContext.Identity.SourceIP
+
 	if req.MultiValueHeaders != nil {
 		for k, values := range req.MultiValueHeaders {
 			for _, value := range values {

--- a/core/requestv2.go
+++ b/core/requestv2.go
@@ -158,13 +158,13 @@ func (r *RequestAccessorV2) EventToRequest(req events.APIGatewayV2HTTPRequest) (
 		bytes.NewReader(decodedBody),
 	)
 
-	httpRequest.RemoteAddr = req.RequestContext.HTTP.SourceIP
-
 	if err != nil {
 		fmt.Printf("Could not convert request %s:%s to http.Request\n", req.RequestContext.HTTP.Method, req.RequestContext.HTTP.Path)
 		log.Println(err)
 		return nil, err
 	}
+
+	httpRequest.RemoteAddr = req.RequestContext.HTTP.SourceIP
 
 	for _, cookie := range req.Cookies {
 		httpRequest.Header.Add("Cookie", cookie)

--- a/core/requestv2.go
+++ b/core/requestv2.go
@@ -123,7 +123,7 @@ func (r *RequestAccessorV2) EventToRequest(req events.APIGatewayV2HTTPRequest) (
 
 	path := req.RawPath
 
-	//if RawPath empty is, populate from request context
+	// if RawPath empty is, populate from request context
 	if len(path) == 0 {
 		path = req.RequestContext.HTTP.Path
 	}
@@ -157,6 +157,8 @@ func (r *RequestAccessorV2) EventToRequest(req events.APIGatewayV2HTTPRequest) (
 		path,
 		bytes.NewReader(decodedBody),
 	)
+
+	httpRequest.RemoteAddr = req.RequestContext.HTTP.SourceIP
 
 	if err != nil {
 		fmt.Printf("Could not convert request %s:%s to http.Request\n", req.RequestContext.HTTP.Method, req.RequestContext.HTTP.Path)


### PR DESCRIPTION
A simple addition of remote address to the request context. Currently it will only work for V2 as it exposes remote address directly in HTTP request descriptor.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fix #123