### PR TITLE
Add missing package name to gin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/awslabs/aws-lambda-go-api-proxy/gin"
+	ginadapter "github.com/awslabs/aws-lambda-go-api-proxy/gin"
 	"github.com/gin-gonic/gin"
 )
 


### PR DESCRIPTION
Fix example code in README for Gin framework


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
