### PR TITLE
Implement Flusher in response

### DIFF
--- a/core/response.go
+++ b/core/response.go
@@ -82,6 +82,13 @@ func (r *ProxyResponseWriter) WriteHeader(status int) {
 	r.status = status
 }
 
+
+// Flush implements the Flusher interface which is called by 
+// some implementers. This is intentionally a no-op
+func (r *ProxyResponseWriter) Flush() {
+	//no-op
+}
+
 // GetProxyResponse converts the data passed to the response writer into
 // an events.APIGatewayProxyResponse object.
 // Returns a populated proxy response object. If the response is invalid, for example


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR implements the Flusher interface on the ProxyResponseWriter. Some underlying implementations expect this interface to be implemented even if its a no-op.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
